### PR TITLE
Use gene ids from fasta

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "reconstructor"
-version = "1.2.0"
+version = "1.2.1-alpha"
 description = "COBRApy Compatible Genome Scale Metabolic Network Reconstruction Tool: Reconstructor"
 authors = ["Matt Jenior and Emma Glass"]
 license = "MIT"

--- a/src/reconstructor/_funcs.py
+++ b/src/reconstructor/_funcs.py
@@ -255,7 +255,6 @@ def add_annotation(model, gram, obj='built'):
     # Genes
     for gene in model.genes:
         gene.annotation['sbo'] = 'SBO:0000243'
-        gene.annotation['kegg.genes'] = gene.id
     
     # Metabolites
     for cpd in model.metabolites:

--- a/src/reconstructor/_funcs.py
+++ b/src/reconstructor/_funcs.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import cobra
 from optlang.symbolics import Zero
 
@@ -26,40 +28,40 @@ def run_blast(inputfile, outputfile, database, processors):
     return outputfile
 
 
-def read_blast(blast_hits):
+def read_blast(blast_hits) -> dict[str, str]:
     """
     Retrieves KEGG hits from blast output.
     """
 
-    hits = set()
+    hits = {}
     with open(blast_hits, 'r') as file:
         for line in file:
-            line = line.split()
-            hits.add(line[1])
+            items = line.split()
+            hits[items[0]] = items[1]
     return hits
 
 
-def genes_to_rxns(kegg_hits, gene_modelseed, organism):
+def genes_to_rxns(kegg_hits: dict[str, str], gene_modelseed: dict[str, list[str]], organism) -> defaultdict[str, list[str]]:
     """
     Translates genes to ModelSEED reactions
     """
+    org_genes = set()
+    if organism != "default":
+        blasted_genes = set(kegg_hits.values())
+        org_genes = _get_org_rxns(gene_modelseed, organism).difference(blasted_genes)
+        print(f"Adding {len(org_genes)} from organism {organism}")
 
-    if organism != 'default':
-        new_hits = _get_org_rxns(gene_modelseed, organism)
-        gene_count = len(kegg_hits)
-        kegg_hits |= new_hits
-        gene_count = len(kegg_hits) - gene_count
-        print('Added', gene_count, 'genes from', organism)
+    rxn_db: defaultdict[str, list[str]] = defaultdict(list)
+    for gene, kegg_gene in kegg_hits.items():
+        for rxn in gene_modelseed.get(kegg_gene, []):
+            rxn = rxn + "_c"
+            rxn_db[rxn].append(gene)
 
-    rxn_db = {}
-    for gene in kegg_hits:
-        for rxn in gene_modelseed.get(gene, []):
-            rxn = rxn + '_c'
-            if rxn in rxn_db:
-                rxn_db[rxn].append(gene)
-            else:
-                rxn_db[rxn] = [gene]
-
+    for kegg_gene in org_genes:
+        for rxn in gene_modelseed.get(kegg_gene, []):
+            rxn = rxn + "_c"
+            rxn_db[rxn].append(kegg_gene)
+    
     return rxn_db
 
 
@@ -77,26 +79,24 @@ def _get_org_rxns(gene_modelseed, organism):
     return set(org_genes)
 
 
-def create_model(rxn_db, universal, input_id):
+def create_model(rxn_db: dict[str, list[str]], universal: cobra.Model, model_id):
     """
     Create draft GENRE and integrate GPRs.
     """
-
-    new_model = cobra.Model('new_model')
+    if model_id == "default":
+        model_id = "new_model"
+    new_model = cobra.Model(model_id)
 
     for x in rxn_db.keys():
         if universal.reactions.has_id(x):
-            rxn = universal.reactions.get_by_id(x)
+            rxn: cobra.Reaction = universal.reactions.get_by_id(x)
             new_model.add_reactions([rxn.copy()])
             new_model.reactions.get_by_id(x).gene_reaction_rule = ' or '.join(rxn_db[x])
-
-    if input_id != 'default':
-        new_model.id = input_id
 
     return new_model
 
 
-def add_names(model, gene_db):
+def add_names(model: cobra.Model, gene_db: dict[str, str]):
     """
     Add gene names.
     """

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -25,16 +25,16 @@ def test_read_blast(blast_output_file: Path):
     and parsed correctly.
     """
     expected = {
-        "aai:AARI_04680",
-        "gvg:HMPREF0421_20718",
-        "cst:CLOST_0588",
-        "vei:Veis_0353",
-        "dwd:DSCW_47150",
-        "gvh:HMPREF9231_1083",
-        "jli:EXU32_08840",
-        "gvh:HMPREF9231_0377",
-        "cth:Cthe_0797",
-        "bbp:BBPR_1794"
+        "WP_004111608.1": "aai:AARI_04680",
+        "WP_004111823.1": "gvg:HMPREF0421_20718",
+        "WP_004112121.1": "cst:CLOST_0588",
+        "WP_004113321.1": "vei:Veis_0353",
+        "WP_004113429.1": "dwd:DSCW_47150",
+        "WP_196227846.1": "gvh:HMPREF9231_1083",
+        "WP_196227848.1": "jli:EXU32_08840",
+        "WP_196227849.1": "gvh:HMPREF9231_0377",
+        "WP_230479112.1": "cth:Cthe_0797",
+        "WP_230479416.1": "bbp:BBPR_1794"
     }
     result = read_blast(blast_output_file)
     assert result == expected
@@ -46,28 +46,28 @@ def test_genes_to_rxns(blast_output_file: Path, modelseed_db: dict[str, list[str
     converted to a dictionary of reactions and associated genes.
     """
     expected = {
-        'rxn38278_c': ['vei:Veis_0353'],
-        'rxn32389_c': ['vei:Veis_0353'],
-        'rxn38702_c': ['vei:Veis_0353'],
-        'rxn03869_c': ['vei:Veis_0353'],
-        'rxn06522_c': ['vei:Veis_0353'],
-        'rxn38142_c': ['vei:Veis_0353'],
-        'rxn02518_c': ['cst:CLOST_0588'],
-        'rxn01962_c': ['cst:CLOST_0588'],
-        'rxn33568_c': ['cst:CLOST_0588'],
-        'rxn32974_c': ['cst:CLOST_0588'],
-        'rxn32148_c': ['cst:CLOST_0588'],
-        'rxn32257_c': ['cst:CLOST_0588'],
-        'rxn33469_c': ['gvh:HMPREF9231_0377'],
-        'rxn01987_c': ['gvh:HMPREF9231_0377'],
-        'rxn02008_c': ['jli:EXU32_08840'],
-        'rxn15597_c': ['cth:Cthe_0797'],
-        'rxn30045_c': ['dwd:DSCW_47150'],
-        'rxn16583_c': ['aai:AARI_04680'],
-        'rxn15443_c': ['bbp:BBPR_1794'],
-        'rxn37953_c': ['gvg:HMPREF0421_20718'],
-        'rxn03408_c': ['gvh:HMPREF9231_1083'],
-        'rxn03933_c': ['gvh:HMPREF9231_1083']
+        "rxn16583_c": ["WP_004111608.1"],
+        "rxn37953_c": ["WP_004111823.1"],
+        "rxn02518_c": ["WP_004112121.1"],
+        "rxn01962_c": ["WP_004112121.1"],
+        "rxn33568_c": ["WP_004112121.1"],
+        "rxn32974_c": ["WP_004112121.1"],
+        "rxn32148_c": ["WP_004112121.1"],
+        "rxn32257_c": ["WP_004112121.1"],
+        "rxn38278_c": ["WP_004113321.1"],
+        "rxn32389_c": ["WP_004113321.1"],
+        "rxn38702_c": ["WP_004113321.1"],
+        "rxn03869_c": ["WP_004113321.1"],
+        "rxn06522_c": ["WP_004113321.1"],
+        "rxn38142_c": ["WP_004113321.1"],
+        "rxn30045_c": ["WP_004113429.1"],
+        "rxn03408_c": ["WP_196227846.1"],
+        "rxn03933_c": ["WP_196227846.1"],
+        "rxn02008_c": ["WP_196227848.1"],
+        "rxn33469_c": ["WP_196227849.1"],
+        "rxn01987_c": ["WP_196227849.1"],
+        "rxn15597_c": ["WP_230479112.1"],
+        "rxn15443_c": ["WP_230479416.1"]
     }
 
     blast_hits = read_blast(blast_output_file)


### PR DESCRIPTION
Instead of the IDs for the genes in the drafted model coming from the KEGG IDs of the blast hits, the gene IDs will now come from the query IDs (i.e., the IDs in the input fasta file). Since we are drafting a model of the organism corresponding to the input fasta file, the gene IDs should correspond to that organism's genes (not to similar genes from other organisms).