### PR TITLE
Invert repo structure

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -46,6 +46,58 @@ files = [
 ]
 
 [[package]]
+name = "black"
+version = "25.11.0"
+description = "The uncompromising code formatter."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "black-25.11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ec311e22458eec32a807f029b2646f661e6859c3f61bc6d9ffb67958779f392e"},
+    {file = "black-25.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1032639c90208c15711334d681de2e24821af0575573db2810b0763bcd62e0f0"},
+    {file = "black-25.11.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c0f7c461df55cf32929b002335883946a4893d759f2df343389c4396f3b6b37"},
+    {file = "black-25.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:f9786c24d8e9bd5f20dc7a7f0cdd742644656987f6ea6947629306f937726c03"},
+    {file = "black-25.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:895571922a35434a9d8ca67ef926da6bc9ad464522a5fe0db99b394ef1c0675a"},
+    {file = "black-25.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cb4f4b65d717062191bdec8e4a442539a8ea065e6af1c4f4d36f0cdb5f71e170"},
+    {file = "black-25.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d81a44cbc7e4f73a9d6ae449ec2317ad81512d1e7dce7d57f6333fd6259737bc"},
+    {file = "black-25.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:7eebd4744dfe92ef1ee349dc532defbf012a88b087bb7ddd688ff59a447b080e"},
+    {file = "black-25.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:80e7486ad3535636657aa180ad32a7d67d7c273a80e12f1b4bfa0823d54e8fac"},
+    {file = "black-25.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6cced12b747c4c76bc09b4db057c319d8545307266f41aaee665540bc0e04e96"},
+    {file = "black-25.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cb2d54a39e0ef021d6c5eef442e10fd71fcb491be6413d083a320ee768329dd"},
+    {file = "black-25.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:ae263af2f496940438e5be1a0c1020e13b09154f3af4df0835ea7f9fe7bfa409"},
+    {file = "black-25.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0a1d40348b6621cc20d3d7530a5b8d67e9714906dfd7346338249ad9c6cedf2b"},
+    {file = "black-25.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:51c65d7d60bb25429ea2bf0731c32b2a2442eb4bd3b2afcb47830f0b13e58bfd"},
+    {file = "black-25.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:936c4dd07669269f40b497440159a221ee435e3fddcf668e0c05244a9be71993"},
+    {file = "black-25.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:f42c0ea7f59994490f4dccd64e6b2dd49ac57c7c84f38b8faab50f8759db245c"},
+    {file = "black-25.11.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:35690a383f22dd3e468c85dc4b915217f87667ad9cce781d7b42678ce63c4170"},
+    {file = "black-25.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dae49ef7369c6caa1a1833fd5efb7c3024bb7e4499bf64833f65ad27791b1545"},
+    {file = "black-25.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bd4a22a0b37401c8e492e994bce79e614f91b14d9ea911f44f36e262195fdda"},
+    {file = "black-25.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:aa211411e94fdf86519996b7f5f05e71ba34835d8f0c0f03c00a26271da02664"},
+    {file = "black-25.11.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3bb5ce32daa9ff0605d73b6f19da0b0e6c1f8f2d75594db539fdfed722f2b06"},
+    {file = "black-25.11.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9815ccee1e55717fe9a4b924cae1646ef7f54e0f990da39a34fc7b264fcf80a2"},
+    {file = "black-25.11.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92285c37b93a1698dcbc34581867b480f1ba3a7b92acf1fe0467b04d7a4da0dc"},
+    {file = "black-25.11.0-cp39-cp39-win_amd64.whl", hash = "sha256:43945853a31099c7c0ff8dface53b4de56c41294fa6783c0441a8b1d9bf668bc"},
+    {file = "black-25.11.0-py3-none-any.whl", hash = "sha256:e3f562da087791e96cefcd9dda058380a442ab322a02e222add53736451f604b"},
+    {file = "black-25.11.0.tar.gz", hash = "sha256:9a323ac32f5dc75ce7470501b887250be5005a01602e931a15e45593f70f6e08"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+packaging = ">=22.0"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+pytokens = ">=0.3.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.10)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
 name = "certifi"
 version = "2025.10.5"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -56,6 +108,38 @@ files = [
     {file = "certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de"},
     {file = "certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43"},
 ]
+
+[[package]]
+name = "click"
+version = "8.1.8"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+markers = "python_version < \"3.11\""
+files = [
+    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
+    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "click"
+version = "8.3.1"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+markers = "python_version >= \"3.11\""
+files = [
+    {file = "click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"},
+    {file = "click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "cobra"
@@ -96,7 +180,7 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
-markers = "sys_platform == \"win32\""
+markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -350,6 +434,18 @@ develop = ["codecov", "pycodestyle", "pytest (>=4.6)", "pytest-cov", "wheel"]
 docs = ["sphinx"]
 gmpy = ["gmpy2 (>=2.1.0a4) ; platform_python_implementation != \"PyPy\""]
 tests = ["pytest (>=4.6)"]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
+    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
+]
 
 [[package]]
 name = "numpy"
@@ -607,6 +703,54 @@ test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.9.2)"]
 
 [[package]]
+name = "pathspec"
+version = "0.12.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
+    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.4.0"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+markers = "python_version < \"3.11\""
+files = [
+    {file = "platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85"},
+    {file = "platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf"},
+]
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.1.3)", "sphinx-autodoc-typehints (>=3)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.4)", "pytest-cov (>=6)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.14.1)"]
+
+[[package]]
+name = "platformdirs"
+version = "4.5.0"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+markers = "python_version >= \"3.11\""
+files = [
+    {file = "platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3"},
+    {file = "platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312"},
+]
+
+[package.extras]
+docs = ["furo (>=2025.9.25)", "proselint (>=0.14)", "sphinx (>=8.2.3)", "sphinx-autodoc-typehints (>=3.2)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.4.2)", "pytest-cov (>=7)", "pytest-mock (>=3.15.1)"]
+type = ["mypy (>=1.18.2)"]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
@@ -847,6 +991,21 @@ files = [
 ]
 
 [[package]]
+name = "pytokens"
+version = "0.3.0"
+description = "A Fast, spec compliant Python 3.14+ tokenizer that runs on older Pythons."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytokens-0.3.0-py3-none-any.whl", hash = "sha256:95b2b5eaf832e469d141a378872480ede3f251a5a5041b8ec6e581d3ac71bbf3"},
+    {file = "pytokens-0.3.0.tar.gz", hash = "sha256:2f932b14ed08de5fcf0b391ace2642f858f1394c0857202959000b68ed7a458a"},
+]
+
+[package.extras]
+dev = ["black", "build", "mypy", "pytest", "pytest-cov", "setuptools", "tox", "twine", "wheel"]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 description = "World timezone definitions, modern and historical"
@@ -960,6 +1119,35 @@ files = [
     {file = "ruamel.yaml.clib-0.2.14-cp39-cp39-win32.whl", hash = "sha256:6d5472f63a31b042aadf5ed28dd3ef0523da49ac17f0463e10fda9c4a2773352"},
     {file = "ruamel.yaml.clib-0.2.14-cp39-cp39-win_amd64.whl", hash = "sha256:8dd3c2cc49caa7a8d64b67146462aed6723a0495e44bf0aa0a2e94beaa8432f6"},
     {file = "ruamel.yaml.clib-0.2.14.tar.gz", hash = "sha256:803f5044b13602d58ea378576dd75aa759f52116a0232608e8fdada4da33752e"},
+]
+
+[[package]]
+name = "ruff"
+version = "0.14.7"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "ruff-0.14.7-py3-none-linux_armv6l.whl", hash = "sha256:b9d5cb5a176c7236892ad7224bc1e63902e4842c460a0b5210701b13e3de4fca"},
+    {file = "ruff-0.14.7-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3f64fe375aefaf36ca7d7250292141e39b4cea8250427482ae779a2aa5d90015"},
+    {file = "ruff-0.14.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93e83bd3a9e1a3bda64cb771c0d47cda0e0d148165013ae2d3554d718632d554"},
+    {file = "ruff-0.14.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3838948e3facc59a6070795de2ae16e5786861850f78d5914a03f12659e88f94"},
+    {file = "ruff-0.14.7-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24c8487194d38b6d71cd0fd17a5b6715cda29f59baca1defe1e3a03240f851d1"},
+    {file = "ruff-0.14.7-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:79c73db6833f058a4be8ffe4a0913b6d4ad41f6324745179bd2aa09275b01d0b"},
+    {file = "ruff-0.14.7-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:12eb7014fccff10fc62d15c79d8a6be4d0c2d60fe3f8e4d169a0d2def75f5dad"},
+    {file = "ruff-0.14.7-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c623bbdc902de7ff715a93fa3bb377a4e42dd696937bf95669118773dbf0c50"},
+    {file = "ruff-0.14.7-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f53accc02ed2d200fa621593cdb3c1ae06aa9b2c3cae70bc96f72f0000ae97a9"},
+    {file = "ruff-0.14.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:281f0e61a23fcdcffca210591f0f53aafaa15f9025b5b3f9706879aaa8683bc4"},
+    {file = "ruff-0.14.7-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:dbbaa5e14148965b91cb090236931182ee522a5fac9bc5575bafc5c07b9f9682"},
+    {file = "ruff-0.14.7-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1464b6e54880c0fe2f2d6eaefb6db15373331414eddf89d6b903767ae2458143"},
+    {file = "ruff-0.14.7-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f217ed871e4621ea6128460df57b19ce0580606c23aeab50f5de425d05226784"},
+    {file = "ruff-0.14.7-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6be02e849440ed3602d2eb478ff7ff07d53e3758f7948a2a598829660988619e"},
+    {file = "ruff-0.14.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:19a0f116ee5e2b468dfe80c41c84e2bbd6b74f7b719bee86c2ecde0a34563bcc"},
+    {file = "ruff-0.14.7-py3-none-win32.whl", hash = "sha256:e33052c9199b347c8937937163b9b149ef6ab2e4bb37b042e593da2e6f6cccfa"},
+    {file = "ruff-0.14.7-py3-none-win_amd64.whl", hash = "sha256:e17a20ad0d3fad47a326d773a042b924d3ac31c6ca6deb6c72e9e6b5f661a7c6"},
+    {file = "ruff-0.14.7-py3-none-win_arm64.whl", hash = "sha256:be4d653d3bea1b19742fcc6502354e32f65cd61ff2fbdb365803ef2c2aec6228"},
+    {file = "ruff-0.14.7.tar.gz", hash = "sha256:3417deb75d23bd14a722b57b0a1435561db65f0ad97435b4cf9f85ffcef34ae5"},
 ]
 
 [[package]]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1141,17 +1141,6 @@ files = [
 ]
 
 [[package]]
-name = "wget"
-version = "3.2"
-description = "pure python download utility"
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "wget-3.2.zip", hash = "sha256:35e630eca2aa50ce998b9b1a127bb26b30dfee573702782aa982f875e3f16061"},
-]
-
-[[package]]
 name = "zipp"
 version = "3.20.2"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -1175,4 +1164,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4"
-content-hash = "e085a51ebe42dcd9117849bb798803def66febedec7545a1de360d2797140da7"
+content-hash = "49ead74c3574a49655cb204a44b4039b1e978d7d7404dd08562fdc63b4e3d985"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1330,15 +1330,15 @@ files = [
 
 [[package]]
 name = "zipp"
-version = "3.20.2"
+version = "3.23.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 markers = "python_version == \"3.9\""
 files = [
-    {file = "zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350"},
-    {file = "zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29"},
+    {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
+    {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
 ]
 
 [package.extras]
@@ -1346,7 +1346,7 @@ check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 enabler = ["pytest-enabler (>=2.2)"]
-test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
+test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
 type = ["pytest-mypy"]
 
 [metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,5 +25,7 @@ build-backend = "poetry.core.masonry.api"
 
 [dependency-groups]
 dev = [
-    "pytest (>=7.0)"
+    "pytest (>=7.0)",
+    "black (>=25.11.0,<26.0.0)",
+    "ruff (>=0.14.7,<0.15.0)"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ exclude = [
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4"
-wget = "^3.2"
 cobra = "^0.29.1"
 
 

--- a/src/UniversalCreation.py
+++ b/src/UniversalCreation.py
@@ -4,13 +4,10 @@
 # In[1]:
 
 
-import symengine
 import cobra
 from copy import deepcopy
 import json
 import pickle
-import pandas
-from optlang.symbolics import Zero
 
 # building the universal model, add all reactions in together make sure syntax is correct, fist step of model creation
 

--- a/src/curateuniversal.py
+++ b/src/curateuniversal.py
@@ -1,16 +1,6 @@
 ##setting up the universal reactions database
 import os
-import cobra
 import pickle
-import argparse
-import warnings
-import symengine
-from random import shuffle
-from multiprocessing import cpu_count
-from sys import stdout
-from copy import deepcopy
-from subprocess import call
-from cobra.util import solver
 from cobra.manipulation.delete import *
 
 script_path = str(os.path.dirname(os.path.realpath(__file__)))

--- a/src/reconstructor/__init__.py
+++ b/src/reconstructor/__init__.py
@@ -1,6 +1,6 @@
 __all__ = [
-    "reconstruct"
+    "reconstruct",
 ]
 
 from reconstructor.build import reconstruct
-from reconstructor._version import __version__
+from reconstructor._version import __version__ as __version__

--- a/src/reconstructor/__init__.py
+++ b/src/reconstructor/__init__.py
@@ -1,6 +1,6 @@
-from reconstructor.build import (
-    reconstruct
-)
+__all__ = [
+    "reconstruct"
+]
 
-
-reconstruct
+from reconstructor.build import reconstruct
+from reconstructor._version import __version__

--- a/src/reconstructor/__main__.py
+++ b/src/reconstructor/__main__.py
@@ -45,8 +45,8 @@ import zipfile
 
 import cobra
 
-from reconstructor.diamond import Diamond, download_diamond, DEFAULT_DIAMOND_VERSION
-from reconstructor import resources, errors, reconstruct
+from reconstructor.diamond import Diamond, download_diamond, DEFAULT_DIAMOND_VERSION, get_diamond_path
+from reconstructor import resources, reconstruct
 
 
 # User defined arguments
@@ -151,14 +151,11 @@ if __name__ == "__main__":
             print(f"Getting DIAMOND v{args.diamond} from {diamond_url}")
             download_diamond(diamond_version=args.diamond)
         if not args.skip_diamond:
-            try:
-                diamond = Diamond()
-            except errors.DiamondNotFoundError:
+            if get_diamond_path() is None:
                 print(f"DIAMOND not found...getting DIAMOND from {diamond_url}")
                 download_diamond()
-                diamond = Diamond()
-            finally:
-                print(f"Using DIAMOND v{diamond.get_version()} at {diamond.path}")
+            diamond = Diamond()
+            print(f"Using DIAMOND v{diamond.get_version()} at {diamond.path}")
 
         # Download the diamond database file if it hasn't been downloaded yet
         diamond_db_path = resources.get_diamond_db_path()

--- a/src/reconstructor/__main__.py
+++ b/src/reconstructor/__main__.py
@@ -45,7 +45,12 @@ import zipfile
 
 import cobra
 
-from reconstructor.diamond import Diamond, download_diamond, DEFAULT_DIAMOND_VERSION, get_diamond_path
+from reconstructor.diamond import (
+    Diamond,
+    download_diamond,
+    DEFAULT_DIAMOND_VERSION,
+    get_diamond_path,
+)
 from reconstructor import resources, reconstruct
 
 

--- a/src/reconstructor/__main__.py
+++ b/src/reconstructor/__main__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env
-'''Reconstructor 
+"""Reconstructor 
 
 Reconstructor is an automatic genome scale metabolic network reconstruction tool that is user-friendly, COBRApy compatible, and uses a pFBA-based
 gap-filling technique. 
@@ -34,50 +34,36 @@ Options for Running Reconstructor
 --name <ID of output GENRE, default = default>
 --cpu <Number of processors to use, default = 1>
 --test <run installation tests, default = no>
-'''
+"""
 
 # Dependencies
-import os
 from pathlib import Path
 import argparse
-from multiprocessing import cpu_count
 from tempfile import TemporaryDirectory
 import zipfile
 
 import cobra
 
-from reconstructor._funcs import (
-    run_blast,
-    read_blast,
-    genes_to_rxns,
-    create_model,
-    add_names,
-    find_reactions,
-    gapfill_model,
-    set_base_inputs,
-    add_annotation,
-    check_model
-)
 from reconstructor.diamond import Diamond, download_diamond, DEFAULT_DIAMOND_VERSION
-from reconstructor import resources, errors
+from reconstructor import resources, errors, reconstruct
 
 
 # User defined arguments
-parser = argparse.ArgumentParser(description='Generate genome-scale metabolic network reconstruction from KEGG BLAST hits.')
-parser.add_argument('--input_file', default='none')
-parser.add_argument('--file_type', default=1, help='Input file type: fasta=1, diamond blastp output=2, genre sbml=3')
-parser.add_argument('--media', default='rich', help='List of metabolites composing the media condition. Not required.')
-parser.add_argument('--tasks', default=[], help='List of metabolic tasks. Not required.')
-parser.add_argument('--org', default='default', help='KEGG organism code. Not required.')
-parser.add_argument('--min_frac', default=0.01, help='Minimum objective fraction required during gapfilling')
-parser.add_argument('--max_frac', default=0.5, help='Maximum objective fraction allowed during gapfilling')
-parser.add_argument('--gram', default='none', help='Type of Gram classificiation (positive or negative)')
-parser.add_argument('--out', default='default', help='Name of output GENRE file')
-parser.add_argument('--name', default='default', help='ID of output GENRE')
-parser.add_argument('--cpu', default=1, help='Number of processors to use')
-parser.add_argument('--gapfill', default='yes', help='gapfill your model?')
-parser.add_argument('--exchange', default = 1, help='open exchange: 1, shut down exchange: 0')
-parser.add_argument('--test', default = 'no', help='do you want to perform the test suite?')
+parser = argparse.ArgumentParser(description="Generate genome-scale metabolic network reconstruction from KEGG BLAST hits.")
+parser.add_argument("--input_file", default=None)
+parser.add_argument("--file_type", default=1, help="Input file type: fasta=1, diamond blastp output=2, genre sbml=3")
+parser.add_argument("--media", default="rich", help="List of metabolites composing the media condition. Not required.")
+parser.add_argument("--tasks", default=None, help="List of metabolic tasks. Not required.")
+parser.add_argument("--org", default=None, help="KEGG organism code. Not required.")
+parser.add_argument("--min_frac", default=0.01, help="Minimum objective fraction required during gapfilling")
+parser.add_argument("--max_frac", default=0.5, help="Maximum objective fraction allowed during gapfilling")
+parser.add_argument("--gram", default="positive", help="Type of Gram classificiation (positive or negative)")
+parser.add_argument("--out", default=None, help="Name of output GENRE file")
+parser.add_argument("--name", default=None, help="ID of output GENRE")
+parser.add_argument("--cpu", default=None, help="Number of processors to use")
+parser.add_argument("--gapfill", default="yes", help="gapfill your model?")
+parser.add_argument("--exchange", default = 1, help="open exchange: 1, shut down exchange: 0")
+parser.add_argument("--test", default = "no", help="do you want to perform the test suite?")
 
 # Diamond download options (only used when running the test suite)
 group = parser.add_mutually_exclusive_group(required=False)
@@ -102,27 +88,34 @@ args = parser.parse_args()
 #----------------------------------------------------------------------------------------------------------------------#
 if __name__ == "__main__":
     # Process input settings
-    input_file = str(args.input_file)
-    out_file = str(args.out)
+    input_file = args.input_file
+    out_file = args.out
     file_type = int(args.file_type)
-    name = str(args.name)
-    org = str(args.org)
-    if args.media in ["default", "default_media", "rich", "minimal"]:
+    org = args.org
+    if args.media in ["complete", "rich", "minimal"]:
         media = str(args.media)
     else:
         media = str(args.media).split(",")
     min_frac = float(args.min_frac)
     max_frac = float(args.max_frac)
-    metabolic_tasks = list(args.tasks)
-    new_id = str(args.name)
-    gram_type = str(args.gram)
-    processors = int(args.cpu)
+
+    if args.tasks is not None:
+        metabolic_tasks = str(args.tasks).split(",")
+    else:
+        metabolic_tasks = None
+    
+    new_id = args.name
+    if new_id is None:
+        new_id = "new_model"
+    
+    gram = args.gram
+    processors = int(args.cpu) if args.cpu is not None else None
     gapfill = str(args.gapfill)
     exchange_arg = int(args.exchange)
     test = str(args.test)
 
     #----------------------------------------------------------------------------------------------------------------------#
-    if test == 'yes':
+    if test == "yes":
 
         # Download a diamond binary if needed
         if args.diamond is not None:
@@ -164,176 +157,46 @@ if __name__ == "__main__":
                     test_file = archive.extract(test_file_name, tempdir)
 
                 # Run reconstructor
+                model = reconstruct(
+                    test_file,
+                    input_type,
+                    gram="negative",
+                    cpu=processors
+                )
+
+                # Save model
                 output_file = Path(test_file).with_suffix(".out.sbml")
-                cmd = f"python -m reconstructor --input_file {test_file} --file_type {input_type} --out {output_file} --gram negative --cpu {processors}"
-                print(cmd)
-                exitcode = os.system(cmd)
-                if exitcode != 0:
-                    raise errors.ReconstructorError(f"Test {test_num} failed with an error")
+                cobra.io.write_sbml_model(model, output_file)
+        
+        print("Tests finished!")
 
         quit()
     #----------------------------------------------------------------------------------------------------------------------#
 
-    if gram_type == 'positive':
-        print('\nUsing Gram positive objective function')
-        universal_obj = 'biomass_GmPos'
-    elif gram_type == 'negative':
-        print('\nUsing Gram negative objective function')
-        universal_obj = 'biomass_GmNeg'
-    else:
-        universal_obj = 'biomass'
-
-    if min_frac <= 0.0 or min_frac > 1.0:
-        print('WARNING: Improper minimum fraction selected. Defaulting to 0.01')
-        min_frac = 0.01
-    if max_frac <= 0.0 or max_frac > 1.0:
-        print('WARNING: Improper maximum fraction selected. Defaulting to 0.5')
-        max_frac = 0.5
-    if max_frac < min_frac:
-        print('WARNING: Input maximum fraction less than minimum fraction. Minimum set to half maximum')
-        min_frac = max_frac * 0.5
-
-    if org != 'default':
-        print('Including additional genes from KEGG genome of', org)
-
-    # Maximum fraction should not be too high, otherwise the gapfiller adds too many reactions
-    print('Using minimum objective flux fraction of', min_frac,'and maximum fraction of', max_frac)
-
-    if processors > cpu_count():
-        print('WARNING: Requested more processors than are available. Using maximum of', cpu_count())
-        processors = cpu_count()
-    print('Using', processors, 'processor(s)\n')
-
-
-    # Load databases
-    print('Loading GENRE construction databases...')
-    kegg_prot_db = resources.get_diamond_db_path()
-    print('\r[                                         ]', end='', flush=True)
-    gene_modelseed = resources.get_gene_mseed_map()
-    print('\r[---------------                          ]', end='', flush=True)
-    universal = resources.get_universal_model()
-    print('\r[------------------------------           ]', end='', flush=True)
-    gene_names = resources.get_gene_name_map()
-    print('\r[-----------------------------------------]')
-
-    # Check input file type
-    if file_type == 1:
-        print('Aligning peptide sequences to KEGG database, may take some time...')
-        blast_results = input_file.rstrip('fastn') + 'KEGGprot.out'
-        print('Blast results will be saved to', blast_results,'\n')
-        run_blast(input_file, blast_results, kegg_prot_db, str(processors))
-    elif file_type == 2:
-        blast_results = input_file
-    else:
-        try:
-            draft_genre = cobra.io.read_sbml_model(input_file)
-        except:
-            draft_genre = cobra.io.load_json_model(input_file)
-
-
-    # Handle gap-filling if that's all that is needed
-    if file_type != 3:
-        if blast_results != 'none':
-            print('Creating draft GENRE from BLAST results...')
-            gene_hits = read_blast(blast_results)
-        else: 
-            gene_hits = set()
-        rxns = genes_to_rxns(gene_hits, gene_modelseed, org)
-        draft_genre = create_model(rxns, universal, new_id)
-        draft_genre = add_names(draft_genre, gene_names)
-    else:
-        universal_obj = str(draft_genre.objective.expression).split()[0].split('*')[-1]
-
-    # Handle media conditions
-    if media == 'rich':
-        media = ['cpd00001_e','cpd00035_e','cpd00041_e','cpd00023_e','cpd00119_e','cpd00107_e','cpd00060_e','cpd00161_e','cpd00069_e','cpd00084_e','cpd00033_e',
-    'cpd00322_e','cpd00066_e','cpd00054_e','cpd00065_e','cpd00156_e','cpd00220_e','cpd00644_e','cpd00393_e','cpd00133_e','cpd00263_e','cpd00104_e','cpd00149_e',
-    'cpd00971_e','cpd00099_e','cpd00205_e','cpd00009_e','cpd00063_e','cpd00254_e','cpd10515_e','cpd00030_e','cpd00242_e','cpd00226_e','cpd01242_e','cpd00307_e',
-    'cpd00092_e','cpd00117_e','cpd00067_e','cpd00567_e','cpd00132_e','cpd00210_e','cpd00320_e','cpd03279_e','cpd00246_e','cpd00311_e','cpd00367_e','cpd00277_e',
-    'cpd00182_e','cpd00654_e','cpd00412_e','cpd00438_e','cpd00274_e','cpd00186_e','cpd00637_e','cpd00105_e','cpd00305_e','cpd00309_e','cpd00098_e','cpd00207_e',
-    'cpd00082_e','cpd00129_e']
-    elif media == 'minimal':
-        media = ['cpd00001_e','cpd00065_e','cpd00060_e','cpd00322_e','cpd00129_e','cpd00156_e','cpd00107_e','cpd00084_e', 
-    'cpd00149_e','cpd00099_e','cpd10515_e','cpd00030_e','cpd00254_e','cpd00063_e','cpd00205_e','cpd00009_e','cpd00971_e','cpd00242_e',
-    'cpd00104_e','cpd00644_e','cpd00263_e','cpd00082_e']
-    elif media == 'default' or media == "default_media":
-        media = ['cpd00035_e','cpd00051_e','cpd00132_e','cpd00041_e','cpd00084_e','cpd00053_e','cpd00023_e',
-    'cpd00033_e','cpd00119_e','cpd00322_e','cpd00107_e','cpd00039_e','cpd00060_e','cpd00066_e','cpd00129_e',
-    'cpd00054_e','cpd00161_e','cpd00065_e','cpd00069_e','cpd00156_e','cpd00027_e','cpd00149_e','cpd00030_e',
-    'cpd00254_e','cpd00971_e','cpd00063_e','cpd10515_e','cpd00205_e','cpd00099_e']
-    else:
-        media = media
-    
-    # Set media condition
-    if len(media) != 0:
-        media_condition = set(['EX_' + cpd for cpd in media])
-        universal_reactions = set([x.id for x in universal.reactions])
-        for rxn in universal_reactions:
-            if rxn.startswith('EX_') == True:
-                universal.reactions.get_by_id(rxn).bounds = (0, 1000.0)
-            if rxn in media_condition:
-                universal.reactions.get_by_id(rxn).bounds = (-1000.0, 10000)
-
-    # Gapfill new model
-    if gapfill == 'yes':
-        if file_type != 3:
-            print('Identifying new metabolism (Step 1 of 2)...')
-        if file_type == 3:
-            print('Identifying new metabolism...')
-        draft_reactions = set([x.id for x in draft_genre.reactions])
-        draft_metabolites = set([x.id for x in draft_genre.metabolites])
-        new_reactions = find_reactions(draft_genre, universal, metabolic_tasks, universal_obj, min_frac, max_frac, 1, file_type)
-        print(new_reactions)
-        filled_genre = gapfill_model(draft_genre, universal, new_reactions, universal_obj, 1)
-        if file_type != 3:
-            print('Identifying new metabolism (Step 2 of 2)...')
-            filled_genre = set_base_inputs(filled_genre, universal)
-            media_reactions = find_reactions(filled_genre, universal, metabolic_tasks, universal_obj, min_frac, max_frac, 2, file_type)
-            final_genre = gapfill_model(filled_genre, universal, media_reactions, universal_obj, 2)
-            final_genre = add_annotation(final_genre, gram_type)
-        else: 
-            final_genre = add_annotation(filled_genre, universal_obj)
-    else:
-        draft_reactions = set([x.id for x in draft_genre.reactions])
-        draft_metabolites = set([x.id for x in draft_genre.metabolites])
-        final_genre = draft_genre
-        final_genre = add_annotation(final_genre, gram_type)
-
-    # Correct exchanges and check new model
-    if exchange_arg == 0:
-        for exch in final_genre.exchanges: exch.bounds = (0., 0.)
-    else:
-        for exch in final_genre.exchanges: exch.bounds = (-1000., 1000.)
-    for rxn in final_genre.reactions:
-        if 'Exchange reaction for' in rxn.name:
-            rxn.name = list(rxn.metabolites)[0].name + ' exchange'
-    biomass = check_model(draft_reactions, draft_metabolites, final_genre)
+    # Perform the reconstruction
+    model = reconstruct(
+        input_file,
+        file_type,
+        media,
+        metabolic_tasks,
+        org,
+        min_frac,
+        max_frac,
+        gram,
+        new_id,
+        processors,
+        gapfill == "yes",
+        exchange_arg == 1
+    )
 
     # Write new model to sbml
-    if out_file == "default":
-        input_file = input_file.split('/')[-1] # write to working directory
-        if file_type == 1:
-            if new_id != 'default':
-                out_file = input_file.rstrip('fastn') + new_id + '.sbml'
-            else:
-                out_file = input_file.rstrip('fastn') + 'sbml'
-        elif file_type == 2:
-            if new_id != 'default':
-                if input_file != 'none':
-                    out_file = input_file.rstrip('out') + new_id + '.sbml'
-                else:
-                    out_file = new_id + '.sbml'
-            else:
-                if org != 'default':
-                    out_file = org + '.sbml'
-                else:
-                    out_file = input_file.rstrip('out') + 'sbml'
-        elif file_type == 3:
-            if new_id != 'default':
-                out_file = input_file.rstrip('sbml') + new_id + '.extended.sbml'
-            else:
-                out_file = input_file.rstrip('sbml') + 'extended.sbml'
+    if out_file is None:
+        input_path = Path(input_file)
+        if file_type == 3:
+            out_file = input_path.with_suffix(".extended.sbml")
+        else:
+            out_file = input_path.with_suffix(".sbml")
 
-    print('\nSaving new GENRE to', out_file, '\n')
-    cobra.io.write_sbml_model(final_genre, out_file)
-
+    print(f"\nSaving new model to {out_file}")
+    cobra.io.write_sbml_model(model, out_file)
+    print("Finished")

--- a/src/reconstructor/__main__.py
+++ b/src/reconstructor/__main__.py
@@ -1,8 +1,9 @@
-#!/usr/bin/env
-"""Reconstructor 
+"""
+Reconstructor
+-------------
 
 Reconstructor is an automatic genome scale metabolic network reconstruction tool that is user-friendly, COBRApy compatible, and uses a pFBA-based
-gap-filling technique. 
+gap-filling technique.
 
 Inputs
 ---------
@@ -20,10 +21,10 @@ Type 1 input:  python -m reconstructor --input Osplanchnicus.aa.fasta --type 1 -
 Type 2 input: python -m reconstructor --input Osplanchnicus.hits.out --type 2 --gram negative --other_args <args>
 Type 3 input: python -m reconstructor --input Osplanchnicus.sbml --type 3 --other_args <args>
 
-Options for Running Reconstructor 
+Options for Running Reconstructor
 ---------------------------------
 --input <input file, Required>
---type <input file type, .fasta = 1, diamond blastp output = 2, .sbml = 3, Required, Default = 1> 
+--type <input file type, .fasta = 1, diamond blastp output = 2, .sbml = 3, Required, Default = 1>
 --gram <Type of Gram classificiation (positive or negative), default = positive>
 --media <List of metabolites composing the media condition. Not required.>
 --tasks <List of metabolic tasks. Not required>
@@ -49,21 +50,49 @@ from reconstructor import resources, errors, reconstruct
 
 
 # User defined arguments
-parser = argparse.ArgumentParser(description="Generate genome-scale metabolic network reconstruction from KEGG BLAST hits.")
+parser = argparse.ArgumentParser(
+    description="Generate genome-scale metabolic network reconstruction from KEGG BLAST hits."
+)
 parser.add_argument("--input_file", default=None)
-parser.add_argument("--file_type", default=1, help="Input file type: fasta=1, diamond blastp output=2, genre sbml=3")
-parser.add_argument("--media", default="rich", help="List of metabolites composing the media condition. Not required.")
-parser.add_argument("--tasks", default=None, help="List of metabolic tasks. Not required.")
+parser.add_argument(
+    "--file_type",
+    default=1,
+    help="Input file type: fasta=1, diamond blastp output=2, genre sbml=3",
+)
+parser.add_argument(
+    "--media",
+    default="rich",
+    help="List of metabolites composing the media condition. Not required.",
+)
+parser.add_argument(
+    "--tasks", default=None, help="List of metabolic tasks. Not required."
+)
 parser.add_argument("--org", default=None, help="KEGG organism code. Not required.")
-parser.add_argument("--min_frac", default=0.01, help="Minimum objective fraction required during gapfilling")
-parser.add_argument("--max_frac", default=0.5, help="Maximum objective fraction allowed during gapfilling")
-parser.add_argument("--gram", default="positive", help="Type of Gram classificiation (positive or negative)")
+parser.add_argument(
+    "--min_frac",
+    default=0.01,
+    help="Minimum objective fraction required during gapfilling",
+)
+parser.add_argument(
+    "--max_frac",
+    default=0.5,
+    help="Maximum objective fraction allowed during gapfilling",
+)
+parser.add_argument(
+    "--gram",
+    default="positive",
+    help="Type of Gram classificiation (positive or negative)",
+)
 parser.add_argument("--out", default=None, help="Name of output GENRE file")
 parser.add_argument("--name", default=None, help="ID of output GENRE")
 parser.add_argument("--cpu", default=None, help="Number of processors to use")
 parser.add_argument("--gapfill", default="yes", help="gapfill your model?")
-parser.add_argument("--exchange", default = 1, help="open exchange: 1, shut down exchange: 0")
-parser.add_argument("--test", default = "no", help="do you want to perform the test suite?")
+parser.add_argument(
+    "--exchange", default=1, help="open exchange: 1, shut down exchange: 0"
+)
+parser.add_argument(
+    "--test", default="no", help="do you want to perform the test suite?"
+)
 
 # Diamond download options (only used when running the test suite)
 group = parser.add_mutually_exclusive_group(required=False)
@@ -72,20 +101,19 @@ group.add_argument(
     nargs="?",
     const=DEFAULT_DIAMOND_VERSION,
     default=None,
-    help="Force DIAMOND to be downloaded when running the test suite, and optionally specify the version"
+    help="Force DIAMOND to be downloaded when running the test suite, and optionally specify the version",
 )
 group.add_argument(
     "--skip-diamond",
     action="store_true",
     default=False,
-    help="Skip downloading a DIAMOND binary if running the test suite"
+    help="Skip downloading a DIAMOND binary if running the test suite",
 )
 
 args = parser.parse_args()
 
 
-
-#----------------------------------------------------------------------------------------------------------------------#
+# ----------------------------------------------------------------------------------------------------------------------#
 if __name__ == "__main__":
     # Process input settings
     input_file = args.input_file
@@ -103,29 +131,30 @@ if __name__ == "__main__":
         metabolic_tasks = str(args.tasks).split(",")
     else:
         metabolic_tasks = None
-    
+
     new_id = args.name
     if new_id is None:
         new_id = "new_model"
-    
+
     gram = args.gram
     processors = int(args.cpu) if args.cpu is not None else None
     gapfill = str(args.gapfill)
     exchange_arg = int(args.exchange)
     test = str(args.test)
 
-    #----------------------------------------------------------------------------------------------------------------------#
+    # ----------------------------------------------------------------------------------------------------------------------#
     if test == "yes":
+        diamond_url = "https://github.com/bbuchfink/diamond/releases"
 
         # Download a diamond binary if needed
         if args.diamond is not None:
-            print(f"Getting DIAMOND v{args.diamond} from https://github.com/bbuchfink/diamond/releases")
+            print(f"Getting DIAMOND v{args.diamond} from {diamond_url}")
             download_diamond(diamond_version=args.diamond)
         if not args.skip_diamond:
             try:
                 diamond = Diamond()
             except errors.DiamondNotFoundError:
-                print("DIAMOND not found...getting DIAMOND from https://github.com/bbuchfink/diamond/releases")
+                print(f"DIAMOND not found...getting DIAMOND from {diamond_url}")
                 download_diamond()
                 diamond = Diamond()
             finally:
@@ -140,36 +169,38 @@ if __name__ == "__main__":
         # - 488.146.clean.fa: an amino acid .fasta file used to test a type 1 input to reconstructor
         # - JCP8151B.KEGGprot.out: a blast output file used to test a type 2 input to reconstructor
         # - fmt.metaG.01044A.bin.149.KEGGprot.sbml: a .sbml genre used to test a type three input to reconstructor
-        test_file_names = ["488.146.clean.fa", "JCP8151B.KEGGprot.out", "fmt.metaG.01044A.bin.149.KEGGprot.sbml"]
+        test_file_names = [
+            "488.146.clean.fa",
+            "JCP8151B.KEGGprot.out",
+            "fmt.metaG.01044A.bin.149.KEGGprot.sbml",
+        ]
         input_types = [1, 2, 3]
         test_num = 0
         for test_file_name, input_type in zip(test_file_names, input_types):
             test_num += 1
             print(f"Performing test {test_num}")
-            
+
             # Temporary directory to hold test files (and clean them up after test finishes)
             with TemporaryDirectory(dir=resources.RESOURCE_DIR) as tempdir:
 
                 # Extract the test file
-                with zipfile.ZipFile(resources.RESOURCE_DIR.joinpath("testfiles.zip")) as archive:
+                zip_path = resources.RESOURCE_DIR / "testfiles.zip"
+                with zipfile.ZipFile(zip_path) as archive:
                     test_file = archive.extract(test_file_name, tempdir)
 
                 # Run reconstructor
                 model = reconstruct(
-                    test_file,
-                    input_type,
-                    gram="negative",
-                    cpu=processors
+                    test_file, input_type, gram="negative", cpu=processors
                 )
 
                 # Save model
                 output_file = Path(test_file).with_suffix(".out.sbml")
                 cobra.io.write_sbml_model(model, output_file)
-        
+
         print("Tests finished!")
 
         quit()
-    #----------------------------------------------------------------------------------------------------------------------#
+    # ----------------------------------------------------------------------------------------------------------------------#
 
     # Perform the reconstruction
     model = reconstruct(
@@ -184,7 +215,7 @@ if __name__ == "__main__":
         new_id,
         processors,
         gapfill == "yes",
-        exchange_arg == 1
+        exchange_arg == 1,
     )
 
     # Write new model to sbml

--- a/src/reconstructor/__main__.py
+++ b/src/reconstructor/__main__.py
@@ -134,9 +134,7 @@ if __name__ == "__main__":
         # Download the diamond database file if it hasn't been downloaded yet
         diamond_db_path = resources.get_diamond_db_path()
         if not diamond_db_path.exists():
-            print("Downloading the DIAMOND database for blasting...")
             resources.download_diamond_db()
-            print("Done")
 
         # Run the three tests (each with a different input file)
         # - 488.146.clean.fa: an amino acid .fasta file used to test a type 1 input to reconstructor

--- a/src/reconstructor/_funcs.py
+++ b/src/reconstructor/_funcs.py
@@ -1,71 +1,88 @@
+from typing import Optional, Union, Sequence, Literal
 from collections import defaultdict
+import os
 
 import cobra
 from optlang.symbolics import Zero
 
 from reconstructor.diamond import Diamond
+from reconstructor import medium, utils
+from reconstructor._version import __version__
 
 
-def run_blast(inputfile, outputfile, database, processors):
+def run_blast(
+        inputfile: Union[str, os.PathLike],
+        outputfile: Union[str, os.PathLike],
+        database: Union[str, os.PathLike],
+        processors: Optional[int] = None
+    ) -> Union[str, os.PathLike]:
     """
     Runs protein BLAST and saves results.
     """
 
-    print('blasting %s vs %s'%(inputfile,database))
+    if processors is None:
+        options = ["--more-sensitive", "--max-target-seqs", "1"]
+    else:
+        options = ["-p", processors, "--more-sensitive", "--max-target-seqs", "1"]
 
     diamond = Diamond()
     diamond.blastp(
         database,
         inputfile,
         outputfile, 
-        "-p", processors,
-        "--more-sensitive",
-        "--max-target-seqs", "1",
+        *options,
         capture_output=True
     )
-    print('finished blast')
 
     return outputfile
 
 
-def read_blast(blast_hits) -> dict[str, str]:
+def read_blast(blast_hits: Union[str, os.PathLike]) -> list[cobra.Gene]:
     """
     Retrieves KEGG hits from blast output.
     """
 
-    hits = {}
+    hits: list[cobra.Gene] = []
     with open(blast_hits, 'r') as file:
         for line in file:
-            items = line.split()
-            hits[items[0]] = items[1]
+            query_id, kegg_id, *_ = line.split()
+            gene = cobra.Gene(utils.sanitize_sbml_id(query_id))
+            gene.annotation["kegg.gene"] = kegg_id
+            hits.append(gene)
     return hits
 
 
-def genes_to_rxns(kegg_hits: dict[str, str], gene_modelseed: dict[str, list[str]], organism) -> defaultdict[str, list[str]]:
+def genes_to_rxns(
+        kegg_hits: list[cobra.Gene],
+        gene_modelseed: dict[str, list[str]],
+        organism: Optional[str]
+    ) -> defaultdict[str, list[cobra.Gene]]:
     """
     Translates genes to ModelSEED reactions
     """
     org_genes = set()
-    if organism != "default":
-        blasted_genes = set(kegg_hits.values())
+    if organism is not None:
+        blasted_genes = set(g.annotation["kegg.gene"] for g in kegg_hits)
         org_genes = _get_org_rxns(gene_modelseed, organism).difference(blasted_genes)
         print(f"Adding {len(org_genes)} from organism {organism}")
 
-    rxn_db: defaultdict[str, list[str]] = defaultdict(list)
-    for gene, kegg_gene in kegg_hits.items():
-        for rxn in gene_modelseed.get(kegg_gene, []):
+    rxn_db: defaultdict[str, list[cobra.Gene]] = defaultdict(list)
+    for gene in kegg_hits:
+        for rxn in gene_modelseed.get(gene.annotation["kegg.gene"], []):
             rxn = rxn + "_c"
             rxn_db[rxn].append(gene)
 
     for kegg_gene in org_genes:
         for rxn in gene_modelseed.get(kegg_gene, []):
             rxn = rxn + "_c"
-            rxn_db[rxn].append(kegg_gene)
+            gene = cobra.Gene(kegg_gene)
+            gene.annotation["kegg.gene"] = kegg_gene
+            rxn_db[rxn].append(gene)
     
     return rxn_db
 
 
-def _get_org_rxns(gene_modelseed, organism):
+def _get_org_rxns(gene_modelseed: dict[str, list[str]], organism: str) -> set[str]:
     """
     Get genes for organism from reference genome.
     """
@@ -79,24 +96,35 @@ def _get_org_rxns(gene_modelseed, organism):
     return set(org_genes)
 
 
-def create_model(rxn_db: dict[str, list[str]], universal: cobra.Model, model_id):
+def create_model(
+        rxn_db: dict[str, list[cobra.Gene]],
+        universal: cobra.Model,
+        model_id: Optional[str] = None
+    ) -> cobra.Model:
     """
     Create draft GENRE and integrate GPRs.
     """
-    if model_id == "default":
-        model_id = "new_model"
     new_model = cobra.Model(model_id)
+    new_model.notes["source"] = f"Reconstructor v{__version__}"
 
-    for x in rxn_db.keys():
-        if universal.reactions.has_id(x):
-            rxn: cobra.Reaction = universal.reactions.get_by_id(x)
+    # Add the genes to the model
+    for gene_lst in rxn_db.values():
+        for gene in gene_lst:
+            if not new_model.genes.has_id(gene.id):
+                new_model.genes.add(gene)
+    
+    # Add the reactions to the model
+    for rxn_id in rxn_db.keys():
+        if universal.reactions.has_id(rxn_id):
+            rxn: cobra.Reaction = universal.reactions.get_by_id(rxn_id)
             new_model.add_reactions([rxn.copy()])
-            new_model.reactions.get_by_id(x).gene_reaction_rule = ' or '.join(rxn_db[x])
+            gpr = " or ".join(g.id for g in rxn_db[rxn_id])
+            new_model.reactions.get_by_id(rxn_id).gene_reaction_rule = gpr
 
     return new_model
 
 
-def add_names(model: cobra.Model, gene_db: dict[str, str]):
+def add_names(model: cobra.Model, gene_db: dict[str, str]) -> cobra.Model:
     """
     Add gene names.
     """
@@ -109,7 +137,16 @@ def add_names(model: cobra.Model, gene_db: dict[str, str]):
     return model
 
 
-def find_reactions(model, reaction_bag, tasks, obj, fraction, max_fraction, step, file_type):
+def find_reactions(
+        model: cobra.Model,
+        reaction_bag: cobra.Model,
+        tasks: Optional[Sequence[str]],
+        obj: str,
+        fraction: float,
+        max_fraction: float,
+        step: Literal[1, 2], 
+        file_type: Literal[1, 2, 3]
+    ) -> set[str]:
     """
     pFBA gapfiller.
     
@@ -147,7 +184,7 @@ def find_reactions(model, reaction_bag, tasks, obj, fraction, max_fraction, step
         universal.add_reactions(add_rxns)
 
         # Set lower bounds for metaboloic tasks
-        if len(tasks) != 0:
+        if tasks is not None:
             for rxn in tasks:
                 if universal.reactions.has_id(rxn):
                     universal.reactions.get_by_id(rxn).lower_bound = fraction
@@ -195,7 +232,13 @@ def find_reactions(model, reaction_bag, tasks, obj, fraction, max_fraction, step
     return(new_rxn_ids)    
 
 
-def gapfill_model(model, universal, new_rxn_ids, obj, step):
+def gapfill_model(
+        model: cobra.Model,
+        universal: cobra.Model,
+        new_rxn_ids: Sequence[str],
+        obj: str,
+        step: Literal[1, 2]
+    ) -> cobra.Model:
     """
     Adds new reactions to model by getting reactions and metabolites to be added
     to the model, creates gapfilled model, and identifies extracellular
@@ -226,15 +269,12 @@ def gapfill_model(model, universal, new_rxn_ids, obj, step):
     return model
 
 
-def set_base_inputs(model, universal):
+def set_base_inputs(model: cobra.Model, universal: cobra.Model) -> cobra.Model:
     """
     Set uptake of specific metabolites in complete medium gap-filling.
     """
 
-    tasks = ['EX_cpd00035_e','EX_cpd00051_e','EX_cpd00132_e','EX_cpd00041_e','EX_cpd00084_e','EX_cpd00053_e','EX_cpd00023_e',
-    'EX_cpd00033_e','EX_cpd00119_e','EX_cpd00322_e','EX_cpd00107_e','EX_cpd00039_e','EX_cpd00060_e','EX_cpd00066_e','EX_cpd00129_e',
-    'EX_cpd00054_e','EX_cpd00161_e','EX_cpd00065_e','EX_cpd00069_e','EX_cpd00156_e','EX_cpd00027_e','EX_cpd00149_e','EX_cpd00030_e',
-    'EX_cpd00254_e','EX_cpd00971_e','EX_cpd00063_e','EX_cpd10515_e','EX_cpd00205_e','EX_cpd00099_e']
+    tasks = [f"EX_{cpd}" for cpd in medium.COMPLETE]
 
     new_rxns = []
     for exch in tasks: 
@@ -247,7 +287,7 @@ def set_base_inputs(model, universal):
     return model
 
 
-def add_annotation(model, gram, obj='built'):
+def add_annotation(model: cobra.Model, gram: str, obj='built') -> cobra.Model:
     """
     Add gene, metabolite, reaction, and biomass reaction annotations.
     """
@@ -293,7 +333,7 @@ def add_annotation(model, gram, obj='built'):
     return model
     
 
-def check_model(pre_reactions, pre_metabolites, post_model):
+def check_model(pre_reactions: Sequence[str], pre_metabolites: Sequence[str], post_model: cobra.Model):
     """
     Run basic checks on new models (checking for objective flux).
     """
@@ -304,7 +344,6 @@ def check_model(pre_reactions, pre_metabolites, post_model):
     new_cpd_ids = set([x.id for x in post_model.metabolites]).difference(pre_metabolites)
     test_flux = round(post_model.slim_optimize(), 3)
 
-	
 	# Report to user
     print('\tDraft reconstruction had', str(new_genes), 'genes,', str(len(pre_reactions)), 'reactions, and', str(len(pre_metabolites)), 'metabolites')
     print('\tGapfilled', str(len(new_rxn_ids)), 'reactions and', str(len(new_cpd_ids)), 'metabolites\n')

--- a/src/reconstructor/_funcs.py
+++ b/src/reconstructor/_funcs.py
@@ -41,7 +41,7 @@ def read_blast(blast_hits: Union[str, os.PathLike]) -> list[cobra.Gene]:
         for line in file:
             query_id, kegg_id, *_ = line.split()
             gene = cobra.Gene(utils.sanitize_sbml_id(query_id))
-            gene.annotation["kegg.gene"] = kegg_id
+            gene.annotation["kegg.genes"] = kegg_id
             hits.append(gene)
     return hits
 
@@ -56,13 +56,13 @@ def genes_to_rxns(
     """
     org_genes = set()
     if organism is not None:
-        blasted_genes = set(g.annotation["kegg.gene"] for g in kegg_hits)
+        blasted_genes = set(g.annotation["kegg.genes"] for g in kegg_hits)
         org_genes = _get_org_rxns(gene_modelseed, organism).difference(blasted_genes)
         print(f"Adding {len(org_genes)} from organism {organism}")
 
     rxn_db: defaultdict[str, list[cobra.Gene]] = defaultdict(list)
     for gene in kegg_hits:
-        for rxn in gene_modelseed.get(gene.annotation["kegg.gene"], []):
+        for rxn in gene_modelseed.get(gene.annotation["kegg.genes"], []):
             rxn = rxn + "_c"
             rxn_db[rxn].append(gene)
 
@@ -70,7 +70,7 @@ def genes_to_rxns(
         for rxn in gene_modelseed.get(kegg_gene, []):
             rxn = rxn + "_c"
             gene = cobra.Gene(kegg_gene)
-            gene.annotation["kegg.gene"] = kegg_gene
+            gene.annotation["kegg.genes"] = kegg_gene
             rxn_db[rxn].append(gene)
 
     return rxn_db

--- a/src/reconstructor/_funcs.py
+++ b/src/reconstructor/_funcs.py
@@ -11,11 +11,11 @@ from reconstructor._version import __version__
 
 
 def run_blast(
-        inputfile: Union[str, os.PathLike],
-        outputfile: Union[str, os.PathLike],
-        database: Union[str, os.PathLike],
-        processors: Optional[int] = None
-    ) -> Union[str, os.PathLike]:
+    inputfile: Union[str, os.PathLike],
+    outputfile: Union[str, os.PathLike],
+    database: Union[str, os.PathLike],
+    processors: Optional[int] = None,
+) -> Union[str, os.PathLike]:
     """
     Runs protein BLAST and saves results.
     """
@@ -26,13 +26,7 @@ def run_blast(
         options = ["-p", processors, "--more-sensitive", "--max-target-seqs", "1"]
 
     diamond = Diamond()
-    diamond.blastp(
-        database,
-        inputfile,
-        outputfile, 
-        *options,
-        capture_output=True
-    )
+    diamond.blastp(database, inputfile, outputfile, *options, capture_output=True)
 
     return outputfile
 
@@ -43,7 +37,7 @@ def read_blast(blast_hits: Union[str, os.PathLike]) -> list[cobra.Gene]:
     """
 
     hits: list[cobra.Gene] = []
-    with open(blast_hits, 'r') as file:
+    with open(blast_hits, "r") as file:
         for line in file:
             query_id, kegg_id, *_ = line.split()
             gene = cobra.Gene(utils.sanitize_sbml_id(query_id))
@@ -53,10 +47,10 @@ def read_blast(blast_hits: Union[str, os.PathLike]) -> list[cobra.Gene]:
 
 
 def genes_to_rxns(
-        kegg_hits: list[cobra.Gene],
-        gene_modelseed: dict[str, list[str]],
-        organism: Optional[str]
-    ) -> defaultdict[str, list[cobra.Gene]]:
+    kegg_hits: list[cobra.Gene],
+    gene_modelseed: dict[str, list[str]],
+    organism: Optional[str],
+) -> defaultdict[str, list[cobra.Gene]]:
     """
     Translates genes to ModelSEED reactions
     """
@@ -78,7 +72,7 @@ def genes_to_rxns(
             gene = cobra.Gene(kegg_gene)
             gene.annotation["kegg.gene"] = kegg_gene
             rxn_db[rxn].append(gene)
-    
+
     return rxn_db
 
 
@@ -89,7 +83,7 @@ def _get_org_rxns(gene_modelseed: dict[str, list[str]], organism: str) -> set[st
 
     org_genes = []
     for gene in gene_modelseed.keys():
-        current = gene.split(':')[0]
+        current = gene.split(":")[0]
         if current == organism:
             org_genes.append(gene)
 
@@ -97,10 +91,10 @@ def _get_org_rxns(gene_modelseed: dict[str, list[str]], organism: str) -> set[st
 
 
 def create_model(
-        rxn_db: dict[str, list[cobra.Gene]],
-        universal: cobra.Model,
-        model_id: Optional[str] = None
-    ) -> cobra.Model:
+    rxn_db: dict[str, list[cobra.Gene]],
+    universal: cobra.Model,
+    model_id: Optional[str] = None,
+) -> cobra.Model:
     """
     Create draft GENRE and integrate GPRs.
     """
@@ -112,7 +106,7 @@ def create_model(
         for gene in gene_lst:
             if not new_model.genes.has_id(gene.id):
                 new_model.genes.add(gene)
-    
+
     # Add the reactions to the model
     for rxn_id in rxn_db.keys():
         if universal.reactions.has_id(rxn_id):
@@ -129,7 +123,7 @@ def add_names(model: cobra.Model, gene_db: dict[str, str]) -> cobra.Model:
     Add gene names.
     """
 
-    #FIXME: the current gene database doesn't have any actual gene names in it
+    # FIXME: the current gene database doesn't have any actual gene names in it
     for gene in model.genes:
         if gene.id in gene_db:
             gene.name = gene_db[gene.id].title()
@@ -138,18 +132,18 @@ def add_names(model: cobra.Model, gene_db: dict[str, str]) -> cobra.Model:
 
 
 def find_reactions(
-        model: cobra.Model,
-        reaction_bag: cobra.Model,
-        tasks: Optional[Sequence[str]],
-        obj: str,
-        fraction: float,
-        max_fraction: float,
-        step: Literal[1, 2], 
-        file_type: Literal[1, 2, 3]
-    ) -> set[str]:
+    model: cobra.Model,
+    reaction_bag: cobra.Model,
+    tasks: Optional[Sequence[str]],
+    obj: str,
+    fraction: float,
+    max_fraction: float,
+    step: Literal[1, 2],
+    file_type: Literal[1, 2, 3],
+) -> set[str]:
     """
     pFBA gapfiller.
-    
+
     Modifies universal reaction bag, removes overlapping reacitons from
     universal reaction bag and resets objective if needed, adds model reaction
     to universal bag, sets lower bound for metabolic tasks, sets minimum lower
@@ -158,17 +152,19 @@ def find_reactions(
     from universal that are now active.
     """
 
-    print('\r[                                         ]', end="", flush=True)
+    print("\r[                                         ]", end="", flush=True)
 
     # Modify universal reaction bag
-    new_rxn_ids = set() #make empty set we will add new reaction ids to
-    with reaction_bag as universal: #set the reaction bag as the universal reaction databse
+    new_rxn_ids = set()  # make empty set we will add new reaction ids to
+    with reaction_bag as universal:  # set the reaction bag as the universal reaction database
 
         # Remove overlapping reactions from universal bag, and reset objective if needed
-        orig_rxn_ids = set()    #original reaction ids start as an empty set
-        remove_rxns = set()    #reactions to remove is empty vector
-        for rxn in model.reactions: #for a reaction in the draft model reactions
-            if rxn.id == obj and file_type != 3: #if a reaction is part of the objective function 
+        orig_rxn_ids = set()
+        remove_rxns = set()
+        for rxn in model.reactions:
+
+            # skip reaction if it is the objective function
+            if rxn.id == obj and file_type != 3:
                 continue
 
             orig_rxn_ids.add(rxn.id)
@@ -183,23 +179,29 @@ def find_reactions(
                 add_rxns.append(x.copy())
         universal.add_reactions(add_rxns)
 
-        # Set lower bounds for metaboloic tasks
+        # Set lower bounds for metabolic tasks
         if tasks is not None:
             for rxn in tasks:
                 if universal.reactions.has_id(rxn):
                     universal.reactions.get_by_id(rxn).lower_bound = fraction
 
-        print('\r[---------------                          ]', end="", flush=True)
+        print("\r[---------------                          ]", end="", flush=True)
 
         # Set minimum lower bound for previous objective
-        universal.objective = universal.reactions.get_by_id(obj) 
+        universal.objective = universal.reactions.get_by_id(obj)
         prev_obj_val = universal.slim_optimize()
         if step == 1:
-            prev_obj_constraint = universal.problem.Constraint(universal.reactions.get_by_id(obj).flux_expression, 
-        	   lb=prev_obj_val*fraction, ub=prev_obj_val*max_fraction)
+            prev_obj_constraint = universal.problem.Constraint(
+                universal.reactions.get_by_id(obj).flux_expression,
+                lb=prev_obj_val * fraction,
+                ub=prev_obj_val * max_fraction,
+            )
         elif step == 2:
-            prev_obj_constraint = universal.problem.Constraint(universal.reactions.get_by_id(obj).flux_expression, 
-               lb=prev_obj_val*max_fraction, ub=prev_obj_val)
+            prev_obj_constraint = universal.problem.Constraint(
+                universal.reactions.get_by_id(obj).flux_expression,
+                lb=prev_obj_val * max_fraction,
+                ub=prev_obj_val,
+            )
         universal.solver.add(prev_obj_constraint)
         universal.solver.update()
 
@@ -213,32 +215,35 @@ def find_reactions(
                 coefficientDict[rxn.forward_variable] = 1.0
                 coefficientDict[rxn.reverse_variable] = 1.0
 
-        print('\r[--------------------------               ]', end="", flush=True)
+        print("\r[--------------------------               ]", end="", flush=True)
 
         # Create objective, based on pFBA
         universal.objective = 0
         universal.solver.update()
-        universal.objective = universal.problem.Objective(Zero, direction='min', sloppy=True)
+        universal.objective = universal.problem.Objective(
+            Zero, direction="min", sloppy=True
+        )
         universal.objective.set_linear_coefficients(coefficientDict)
-        
-        print('\r[----------------------------------       ]', end="", flush=True)
+
+        print("\r[----------------------------------       ]", end="", flush=True)
 
         # Run FBA and identify reactions from universal that are now active
         solution = universal.optimize()
-        
-    new_rxn_ids = set([rxn.id for rxn in reaction_bag.reactions if abs(solution.fluxes[rxn.id]) > 1e-6]).difference(orig_rxn_ids)
-    print('\r[-----------------------------------------]')
 
-    return(new_rxn_ids)    
+    active_rxns = solution.fluxes[solution.fluxes.abs() > 1e-6]
+    new_rxn_ids = set(active_rxns.index).difference(orig_rxn_ids)
+    print("\r[-----------------------------------------]")
+
+    return new_rxn_ids
 
 
 def gapfill_model(
-        model: cobra.Model,
-        universal: cobra.Model,
-        new_rxn_ids: Sequence[str],
-        obj: str,
-        step: Literal[1, 2]
-    ) -> cobra.Model:
+    model: cobra.Model,
+    universal: cobra.Model,
+    new_rxn_ids: Sequence[str],
+    obj: str,
+    step: Literal[1, 2],
+) -> cobra.Model:
     """
     Adds new reactions to model by getting reactions and metabolites to be added
     to the model, creates gapfilled model, and identifies extracellular
@@ -247,24 +252,29 @@ def gapfill_model(
 
     # Get reactions and metabolites to be added to the model
     new_rxns = []
-    if step == 1: new_rxns.append(universal.reactions.get_by_id(obj).copy())
-    for rxn in new_rxn_ids: 
+    if step == 1:
+        new_rxns.append(universal.reactions.get_by_id(obj).copy())
+    for rxn in new_rxn_ids:
         if rxn != obj:
             new_rxns.append(universal.reactions.get_by_id(rxn).copy())
-    
-    # Create gapfilled model 
+
+    # Create gapfilled model
     model.add_reactions(new_rxns)
-    model.objective = model.problem.Objective(model.reactions.get_by_id(obj).flux_expression, direction='max')
+    model.objective = model.problem.Objective(
+        model.reactions.get_by_id(obj).flux_expression, direction="max"
+    )
 
     # Identify extracellular metabolites still need exchanges
     for cpd in model.metabolites:
-        if cpd.compartment != 'extracellular':
+        if cpd.compartment != "extracellular":
             continue
         else:
-            exch_id = 'EX_' + cpd.id
+            exch_id = "EX_" + cpd.id
             if not model.reactions.has_id(exch_id):
-                model.add_boundary(cpd, type='exchange', reaction_id=exch_id, lb=-1000.0, ub=1000.0)
-                model.reactions.get_by_id(exch_id).name = cpd.name + ' exchange'
+                model.add_boundary(
+                    cpd, type="exchange", reaction_id=exch_id, lb=-1000.0, ub=1000.0
+                )
+                model.reactions.get_by_id(exch_id).name = cpd.name + " exchange"
 
     return model
 
@@ -277,77 +287,113 @@ def set_base_inputs(model: cobra.Model, universal: cobra.Model) -> cobra.Model:
     tasks = [f"EX_{cpd}" for cpd in medium.COMPLETE]
 
     new_rxns = []
-    for exch in tasks: 
+    for exch in tasks:
         if not model.reactions.has_id(exch):
             new_rxns.append(universal.reactions.get_by_id(exch).copy())
     model.add_reactions(new_rxns)
     for exch in tasks:
-        model.reactions.get_by_id(exch).bounds = (-1000., -0.01)
+        model.reactions.get_by_id(exch).bounds = (-1000.0, -0.01)
 
     return model
 
 
-def add_annotation(model: cobra.Model, gram: str, obj='built') -> cobra.Model:
+def add_annotation(model: cobra.Model, gram: str, obj="built") -> cobra.Model:
     """
     Add gene, metabolite, reaction, and biomass reaction annotations.
     """
 
     # Genes
     for gene in model.genes:
-        gene.annotation['sbo'] = 'SBO:0000243'
-    
+        gene.annotation["sbo"] = "SBO:0000243"
+
     # Metabolites
     for cpd in model.metabolites:
-        cpd.annotation['sbo'] = 'SBO:0000247'
-        if 'cpd' in cpd.id: cpd.annotation['seed.compound'] = cpd.id.split('_')[0]
+        cpd.annotation["sbo"] = "SBO:0000247"
+        if "cpd" in cpd.id:
+            cpd.annotation["seed.compound"] = cpd.id.split("_")[0]
 
     # Reactions
     for rxn in model.reactions:
-        if 'rxn' in rxn.id: rxn.annotation['seed.reaction'] = rxn.id.split('_')[0]
+        if "rxn" in rxn.id:
+            rxn.annotation["seed.reaction"] = rxn.id.split("_")[0]
         compartments = set([x.compartment for x in list(rxn.metabolites)])
         if len(list(rxn.metabolites)) == 1:
-            rxn.annotation['sbo'] = 'SBO:0000627' # exchange
+            rxn.annotation["sbo"] = "SBO:0000627"  # exchange
         elif len(compartments) > 1:
-            rxn.annotation['sbo'] = 'SBO:0000185' # transport
+            rxn.annotation["sbo"] = "SBO:0000185"  # transport
         else:
-            rxn.annotation['sbo'] = 'SBO:0000176' # metabolic
+            rxn.annotation["sbo"] = "SBO:0000176"  # metabolic
 
     # Biomass reactions
-    if obj == 'built':
+    if obj == "built":
         try:
-            model.reactions.EX_biomass.annotation['sbo'] = 'SBO:0000632'
-        except:
+            model.reactions.EX_biomass.annotation["sbo"] = "SBO:0000632"
+        except AttributeError:
             pass
-        if gram == 'none':
-            biomass_ids = ['dna_rxn','rna_rxn','protein_rxn','teichoicacid_rxn','lipid_rxn','cofactor_rxn','rxn10088_c','biomass_rxn']
+        if gram == "none":
+            biomass_ids = [
+                "dna_rxn",
+                "rna_rxn",
+                "protein_rxn",
+                "teichoicacid_rxn",
+                "lipid_rxn",
+                "cofactor_rxn",
+                "rxn10088_c",
+                "biomass_rxn",
+            ]
         else:
-            biomass_ids = ['dna_rxn','rna_rxn','protein_rxn','teichoicacid_rxn','peptidoglycan_rxn','lipid_rxn','cofactor_rxn','GmPos_cellwall','rxn10088_c','GmNeg_cellwall','biomass_rxn_gp','biomass_rxn_gn']
+            biomass_ids = [
+                "dna_rxn",
+                "rna_rxn",
+                "protein_rxn",
+                "teichoicacid_rxn",
+                "peptidoglycan_rxn",
+                "lipid_rxn",
+                "cofactor_rxn",
+                "GmPos_cellwall",
+                "rxn10088_c",
+                "GmNeg_cellwall",
+                "biomass_rxn_gp",
+                "biomass_rxn_gn",
+            ]
         for x in biomass_ids:
             try:
-                model.reactions.get_by_id(x).annotation['sbo'] = 'SBO:0000629'
-            except:
+                model.reactions.get_by_id(x).annotation["sbo"] = "SBO:0000629"
+            except KeyError:
                 continue
     else:
-        model.reactions.get_by_id(obj).annotation['sbo'] = 'SBO:0000629'
+        model.reactions.get_by_id(obj).annotation["sbo"] = "SBO:0000629"
 
     return model
-    
 
-def check_model(pre_reactions: Sequence[str], pre_metabolites: Sequence[str], post_model: cobra.Model):
+
+def check_model(
+    pre_reactions: Sequence[str],
+    pre_metabolites: Sequence[str],
+    post_model: cobra.Model,
+):
     """
     Run basic checks on new models (checking for objective flux).
     """
 
-	# Check for objective flux
+    # Check for objective flux
     new_genes = len(post_model.genes)
     new_rxn_ids = set([x.id for x in post_model.reactions]).difference(pre_reactions)
-    new_cpd_ids = set([x.id for x in post_model.metabolites]).difference(pre_metabolites)
+    new_cpd_ids = set([x.id for x in post_model.metabolites]).difference(
+        pre_metabolites
+    )
     test_flux = round(post_model.slim_optimize(), 3)
 
-	# Report to user
-    print('\tDraft reconstruction had', str(new_genes), 'genes,', str(len(pre_reactions)), 'reactions, and', str(len(pre_metabolites)), 'metabolites')
-    print('\tGapfilled', str(len(new_rxn_ids)), 'reactions and', str(len(new_cpd_ids)), 'metabolites\n')
-    print('\tFinal reconstruction has', str(len(post_model.reactions)), 'reactions and', str(len(post_model.metabolites)), 'metabolites')
-    print('\tFinal objective flux is', str(round(test_flux, 3)))
+    # Report to user
+    print(
+        f"\tDraft reconstruction had {new_genes} genes, {len(pre_reactions)} reactions, and {len(pre_metabolites)} metabolites"
+    )
+    print(
+        f"\tGapfilled {len(new_rxn_ids)} reactions and {len(new_cpd_ids)} metabolites\n"
+    )
+    print(
+        f"\tFinal reconstruction has {len(post_model.reactions)} reactions and {len(post_model.metabolites)} metabolites"
+    )
+    print(f"\tFinal objective flux is {round(test_flux, 3)}")
 
     return test_flux

--- a/src/reconstructor/_version.py
+++ b/src/reconstructor/_version.py
@@ -1,0 +1,6 @@
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version(__package__)
+except PackageNotFoundError:
+    __version__ = None

--- a/src/reconstructor/build.py
+++ b/src/reconstructor/build.py
@@ -1,11 +1,217 @@
+from typing import Union, Literal, Sequence, Optional
+import warnings
 import os
+import enum
+from pathlib import Path
 
-def reconstruct(input_file, file_type = 1, media=[], org = 'default', min_frac = 0.01, max_frac = 0.5, gram='none', out = 'default', name = 'default', cpu = 1, gapfill = 'yes', test = 'no'):
-    print('Generating reconstruction....')
-    cmd_line = 'python -m reconstructor --input_file %s --file_type %s --media %s --org %s --min_frac %s --max_frac %s --gram %s --out %s --name %s --cpu %s --gapfill %s --test %s'%(input_file,file_type,media,org,min_frac,max_frac,gram,out,name,cpu,gapfill,test)
-    print('Reconstruction generating with the following command line:')
-    print(cmd_line)
-    os.system(cmd_line)
+import cobra
 
-if __name__ == '__main__':
-    reconstruct('218496.4.fa', file_type = 1, gram = 'negative')
+from reconstructor import resources, _funcs
+from reconstructor.medium import get_medium
+
+
+class FileType(enum.Enum):
+    FASTA = 1
+    BLAST_OUTPUT = 2
+    SBML = 3
+
+
+def reconstruct(
+        input_file: Union[str, os.PathLike],
+        file_type: Literal[1, 2, 3] = 1,
+        media: Union[Literal["rich", "minimal", "complete"], Sequence[str]] = "rich",
+        tasks: Optional[Sequence[str]] = None,
+        org: Optional[str] = None,
+        min_frac: float = 0.01,
+        max_frac: float = 0.5,
+        gram: Literal["positive", "negative"] = "positive",
+        model_id: Optional[str] = None,
+        cpu: Optional[int] = None,
+        gapfill: bool = True,
+        open_exchanges: bool = True
+    ) -> cobra.Model:
+    """
+    Reconstruct a genome-scale metabolic model from an input file.
+
+    For a FASTA input, uses DIAMOND to find similar protein sequences in KEGG.
+    The blast output is then used to create a draft metabolic model, which is
+    gap-filled with a pFBA-based approach.
+
+    Parameters
+    ----------
+    input_file : str | PathLike
+        The file path to the input file. The input file should be 1) a FASTA
+        with amino acid sequences, 2) a tsv output from DIAMOND blast, or 3) an
+        SBML model file.
+    
+    file_type : Literal[1, 2, 3]
+        1 for a FASTA file, 2 for a DIAMOND blast output file, or 3 for an SBML
+        model file. The default is 1.
+
+    media : str | Sequence[str]
+        Either the name of a registered media composition ("rich", "minimal", or
+        "complete") or a sequence of extracellular metabolite IDs. The default
+        is "rich".
+
+    tasks : Sequence[str], optional
+        A sequence of reaction IDs that should be active when gap-filling.
+        Default is None.
+
+    org : str, optional
+        A KEGG organism ID. If supplied, all genes from this organism will added
+        to the DIAMOND blast results. Default is None.
+
+    min_frac : float
+        The minimum objective fraction to use for pFBA gap-filling. Default is
+        0.01.
+
+    max_frac : float
+        The maximum objective fraction to use for pFBA gap-filling. Default is
+        0.5.
+
+    gram : str
+        The gram stain of the bacteria for which a model is being reconstructed.
+        This will be used to determine the objective function for the model.
+        Should either be "positive" or "negative". Default is "positive".
+
+    model_id : str, optional
+        The ID to use for the model that is created.
+
+    cpu : int, optional
+        How many processors to use for DIAMOND. Default is None, which means
+        that DIAMOND will automatically detect how many to use.
+
+    gapfill : bool
+        Whether or not to perform pFBA gap-filling on the model. Default is
+        True.
+
+    open_exchanges : bool
+        Whether or not to set the exchanges of the returned model to open or
+        not. Default is True.
+
+    Returns
+    -------
+    cobra.Model
+        The reconstructed metabolic model as a COBRApy model.
+    """
+
+    # Convert input_file to path and ensure it exists
+    input_path = Path(input_file)
+    if not input_path.exists():
+        raise FileNotFoundError(f"The provided input file path does not exist: {input_file}")
+
+    # Convert file type to enum value
+    ftype = FileType(file_type)
+    
+    # Select the biomass objective function
+    if gram == "positive":
+        universal_obj = "biomass_GmPos"
+    elif gram == "negative":
+        universal_obj = "biomass_GmNeg"
+    else:
+        raise ValueError(f"Unrecognized gram stain value: {repr(gram)}. Should be 'positive', 'negative', or None.")
+
+    # Ensure min/max fractions are properly set
+    if min_frac <= 0.0 or min_frac > 1.0:
+        warnings.warn(f"Improper minimum fraction selected ({repr(min_frac)}). Defaulting to 0.01")
+        min_frac = 0.01
+    if max_frac <= 0.0 or max_frac > 1.0:
+        warnings.warn(f"Improper maximum fraction selected ({repr(max_frac)}). Defaulting to 0.5")
+        max_frac = 0.5
+    if max_frac < min_frac:
+        warnings.warn(f"Input maximum fraction ({repr(max_frac)}) less than minimum fraction ({repr(min_frac)}). Minimum set to half maximum")
+        min_frac = max_frac * 0.5
+
+    # Determine the media for gap-filling
+    if isinstance(media, str):
+        media = get_medium(media)
+
+    # Load universal reaction model
+    print("Loading universal model...")
+    universal = resources.get_universal_model()
+
+    if ftype in [FileType.FASTA, FileType.BLAST_OUTPUT]:
+        # Run BLAST if needed
+        if ftype == FileType.FASTA:
+            print(f"Blasting input sequences against KEGG database, may take some time...")
+            blast_db = resources.get_diamond_db_path()
+            blast_file = input_path.with_suffix(".KEGGprot.out")
+            _funcs.run_blast(input_path, blast_file, blast_db, cpu)
+        else:
+            blast_file = input_path
+
+        # Draft model from BLAST output
+        print(f"Drafting model from BLAST results...")
+        gene_hits = _funcs.read_blast(blast_file)
+
+        gene_modelseed = resources.get_gene_mseed_map()
+        rxns = _funcs.genes_to_rxns(gene_hits, gene_modelseed, org)
+
+        draft_model = _funcs.create_model(rxns, universal, model_id)
+
+        gene_names = resources.get_gene_name_map()
+        draft_model = _funcs.add_names(draft_model, gene_names)
+    
+    else:
+        try:
+            draft_model = cobra.io.read_sbml_model(input_path)
+        except:
+            draft_model = cobra.io.load_json_model(input_path)
+        universal_obj = str(draft_model.objective.expression).split()[0].split('*')[-1]
+
+    # Reactions/metabolites in draft model
+    draft_reactions = set([x.id for x in draft_model.reactions])
+    draft_metabolites = set([x.id for x in draft_model.metabolites])
+
+    if gapfill:
+        print("Gapfilling model...")
+
+        # Set the medium on the universal model
+        medium_dict = {}
+        for cpd in media:
+            exch_id = f"EX_{cpd}"
+            if universal.reactions.has_id(exch_id):
+                medium_dict[exch_id] = 1000
+        universal.medium = medium_dict
+
+        # First round of gap-filling
+        new_reactions = _funcs.find_reactions(
+            draft_model,
+            universal,
+            tasks,
+            universal_obj,
+            min_frac,
+            max_frac,
+            1,
+            file_type
+        )
+        filled_model = _funcs.gapfill_model(draft_model, universal, new_reactions, universal_obj, 1)
+
+        if ftype != FileType.SBML:
+            filled_model = _funcs.set_base_inputs(filled_model, universal)
+            media_reactions = _funcs.find_reactions(
+                filled_model,
+                universal,
+                tasks,
+                universal_obj,
+                min_frac,
+                max_frac,
+                2,
+                file_type
+            )
+            final_model = _funcs.gapfill_model(filled_model, universal, media_reactions, universal_obj, 2)
+            final_model = _funcs.add_annotation(final_model, gram)
+        else:
+            final_model = _funcs.add_annotation(filled_model, universal_obj)
+    
+    else:
+        final_model = _funcs.add_annotation(draft_model, gram)
+
+    exchange_bounds = (-1000.0, 1000.0) if open_exchanges else (0.0, 0.0)
+    for exch in final_model.exchanges:
+        exch.bounds = exchange_bounds
+    
+    # Check the final model
+    _funcs.check_model(draft_reactions, draft_metabolites, final_model)
+
+    return final_model

--- a/src/reconstructor/build.py
+++ b/src/reconstructor/build.py
@@ -5,6 +5,7 @@ import enum
 from pathlib import Path
 
 import cobra
+from cobra.io.sbml import CobraSBMLError
 
 from reconstructor import resources, _funcs
 from reconstructor.medium import get_medium
@@ -17,19 +18,19 @@ class FileType(enum.Enum):
 
 
 def reconstruct(
-        input_file: Union[str, os.PathLike],
-        file_type: Literal[1, 2, 3] = 1,
-        media: Union[Literal["rich", "minimal", "complete"], Sequence[str]] = "rich",
-        tasks: Optional[Sequence[str]] = None,
-        org: Optional[str] = None,
-        min_frac: float = 0.01,
-        max_frac: float = 0.5,
-        gram: Literal["positive", "negative"] = "positive",
-        model_id: Optional[str] = None,
-        cpu: Optional[int] = None,
-        gapfill: bool = True,
-        open_exchanges: bool = True
-    ) -> cobra.Model:
+    input_file: Union[str, os.PathLike],
+    file_type: Literal[1, 2, 3] = 1,
+    media: Union[Literal["rich", "minimal", "complete"], Sequence[str]] = "rich",
+    tasks: Optional[Sequence[str]] = None,
+    org: Optional[str] = None,
+    min_frac: float = 0.01,
+    max_frac: float = 0.5,
+    gram: Literal["positive", "negative"] = "positive",
+    model_id: Optional[str] = None,
+    cpu: Optional[int] = None,
+    gapfill: bool = True,
+    open_exchanges: bool = True,
+) -> cobra.Model:
     """
     Reconstruct a genome-scale metabolic model from an input file.
 
@@ -43,7 +44,7 @@ def reconstruct(
         The file path to the input file. The input file should be 1) a FASTA
         with amino acid sequences, 2) a tsv output from DIAMOND blast, or 3) an
         SBML model file.
-    
+
     file_type : Literal[1, 2, 3]
         1 for a FASTA file, 2 for a DIAMOND blast output file, or 3 for an SBML
         model file. The default is 1.
@@ -98,28 +99,38 @@ def reconstruct(
     # Convert input_file to path and ensure it exists
     input_path = Path(input_file)
     if not input_path.exists():
-        raise FileNotFoundError(f"The provided input file path does not exist: {input_file}")
+        raise FileNotFoundError(
+            f"The provided input file path does not exist: {input_file}"
+        )
 
     # Convert file type to enum value
     ftype = FileType(file_type)
-    
+
     # Select the biomass objective function
     if gram == "positive":
         universal_obj = "biomass_GmPos"
     elif gram == "negative":
         universal_obj = "biomass_GmNeg"
     else:
-        raise ValueError(f"Unrecognized gram stain value: {repr(gram)}. Should be 'positive', 'negative', or None.")
+        raise ValueError(
+            f"Unrecognized gram stain value: {repr(gram)}. Should be 'positive', 'negative', or None."
+        )
 
     # Ensure min/max fractions are properly set
     if min_frac <= 0.0 or min_frac > 1.0:
-        warnings.warn(f"Improper minimum fraction selected ({repr(min_frac)}). Defaulting to 0.01")
+        warnings.warn(
+            f"Improper minimum fraction selected ({repr(min_frac)}). Defaulting to 0.01"
+        )
         min_frac = 0.01
     if max_frac <= 0.0 or max_frac > 1.0:
-        warnings.warn(f"Improper maximum fraction selected ({repr(max_frac)}). Defaulting to 0.5")
+        warnings.warn(
+            f"Improper maximum fraction selected ({repr(max_frac)}). Defaulting to 0.5"
+        )
         max_frac = 0.5
     if max_frac < min_frac:
-        warnings.warn(f"Input maximum fraction ({repr(max_frac)}) less than minimum fraction ({repr(min_frac)}). Minimum set to half maximum")
+        warnings.warn(
+            f"Input maximum fraction ({repr(max_frac)}) less than minimum fraction ({repr(min_frac)}). Minimum set to half maximum"
+        )
         min_frac = max_frac * 0.5
 
     # Determine the media for gap-filling
@@ -133,7 +144,9 @@ def reconstruct(
     if ftype in [FileType.FASTA, FileType.BLAST_OUTPUT]:
         # Run BLAST if needed
         if ftype == FileType.FASTA:
-            print(f"Blasting input sequences against KEGG database, may take some time...")
+            print(
+                "Blasting input sequences against KEGG database, may take some time..."
+            )
             blast_db = resources.get_diamond_db_path()
             blast_file = input_path.with_suffix(".KEGGprot.out")
             _funcs.run_blast(input_path, blast_file, blast_db, cpu)
@@ -141,7 +154,7 @@ def reconstruct(
             blast_file = input_path
 
         # Draft model from BLAST output
-        print(f"Drafting model from BLAST results...")
+        print("Drafting model from BLAST results...")
         gene_hits = _funcs.read_blast(blast_file)
 
         gene_modelseed = resources.get_gene_mseed_map()
@@ -151,13 +164,13 @@ def reconstruct(
 
         gene_names = resources.get_gene_name_map()
         draft_model = _funcs.add_names(draft_model, gene_names)
-    
+
     else:
         try:
             draft_model = cobra.io.read_sbml_model(input_path)
-        except:
+        except CobraSBMLError:
             draft_model = cobra.io.load_json_model(input_path)
-        universal_obj = str(draft_model.objective.expression).split()[0].split('*')[-1]
+        universal_obj = str(draft_model.objective.expression).split()[0].split("*")[-1]
 
     # Reactions/metabolites in draft model
     draft_reactions = set([x.id for x in draft_model.reactions])
@@ -183,9 +196,11 @@ def reconstruct(
             min_frac,
             max_frac,
             1,
-            file_type
+            file_type,
         )
-        filled_model = _funcs.gapfill_model(draft_model, universal, new_reactions, universal_obj, 1)
+        filled_model = _funcs.gapfill_model(
+            draft_model, universal, new_reactions, universal_obj, 1
+        )
 
         if ftype != FileType.SBML:
             filled_model = _funcs.set_base_inputs(filled_model, universal)
@@ -197,20 +212,22 @@ def reconstruct(
                 min_frac,
                 max_frac,
                 2,
-                file_type
+                file_type,
             )
-            final_model = _funcs.gapfill_model(filled_model, universal, media_reactions, universal_obj, 2)
+            final_model = _funcs.gapfill_model(
+                filled_model, universal, media_reactions, universal_obj, 2
+            )
             final_model = _funcs.add_annotation(final_model, gram)
         else:
             final_model = _funcs.add_annotation(filled_model, universal_obj)
-    
+
     else:
         final_model = _funcs.add_annotation(draft_model, gram)
 
     exchange_bounds = (-1000.0, 1000.0) if open_exchanges else (0.0, 0.0)
     for exch in final_model.exchanges:
         exch.bounds = exchange_bounds
-    
+
     # Check the final model
     _funcs.check_model(draft_reactions, draft_metabolites, final_model)
 

--- a/src/reconstructor/diamond.py
+++ b/src/reconstructor/diamond.py
@@ -67,7 +67,7 @@ class Diamond:
         args = ["blastp", "--db", db, "--query", query]
         if out is not None:
             args.extend(["--out", out])
-        args.extend(options)
+        args.extend([str(x) for x in options])
         return self.__call__(args, **sp_kwargs)
     
     def get_version(self):

--- a/src/reconstructor/diamond.py
+++ b/src/reconstructor/diamond.py
@@ -13,14 +13,8 @@ import subprocess
 import re
 
 from reconstructor import errors
+from reconstructor.utils import download, CallbackT, DownloadProgress
 
-
-_CALLBACK = Callable[[int, int, int], Any]
-_DOWNLOAD_PROGRESS = lambda count, block, total: print(
-    f"\rDownloading... {count*block/total:.1%}",
-    end=("" if count*block < total else "\n"),
-    flush=True
-)
 
 DEFAULT_DIAMOND_VERSION = "2.1.14"
 _DIAMOND_URL_TEMPLATE = "https://github.com/bbuchfink/diamond/releases/download/v{version}/diamond-{system}{ext}"
@@ -104,7 +98,7 @@ def download_diamond(
         dir: Optional[Union[str, bytes, os.PathLike]] = _BIN_DIR,
         diamond_version: str = DEFAULT_DIAMOND_VERSION,
         bin_name: Optional[str] = None,
-        callback: Optional[_CALLBACK] = _DOWNLOAD_PROGRESS
+        callback: Optional[CallbackT] = DownloadProgress()
     ) -> str:
     """
     Download the appropriate DIAMOND binary for the operating system from
@@ -135,7 +129,12 @@ def cleanup_bin():
         shutil.rmtree(_BIN_DIR)
 
 
-def _download_windows(dir: Optional[Union[str, bytes, os.PathLike]], diamond_version: str, bin_name: Optional[str], callback: Optional[_CALLBACK] = None) -> str:
+def _download_windows(
+        dir: Optional[Union[str, bytes, os.PathLike]],
+        diamond_version: str,
+        bin_name: Optional[str],
+        callback: Optional[CallbackT] = None
+    ) -> str:
     if bin_name is None:
         bin_name = _WINDOWS_BIN
 
@@ -147,7 +146,12 @@ def _download_windows(dir: Optional[Union[str, bytes, os.PathLike]], diamond_ver
     return os.path.join(dir, bin_name)
 
 
-def _download_macos(dir: Optional[Union[str, bytes, os.PathLike]], diamond_version: str, bin_name: Optional[str], callback: Optional[_CALLBACK] = None) -> str:
+def _download_macos(
+        dir: Optional[Union[str, bytes, os.PathLike]],
+        diamond_version: str,
+        bin_name: Optional[str],
+        callback: Optional[CallbackT] = None
+    ) -> str:
     if bin_name is None:
         bin_name = _MACOS_BIN
 
@@ -159,7 +163,12 @@ def _download_macos(dir: Optional[Union[str, bytes, os.PathLike]], diamond_versi
     return os.path.join(dir, bin_name)
 
 
-def _download_linux(dir: Optional[Union[str, bytes, os.PathLike]], diamond_version: str, bin_name: Optional[str], callback: Optional[_CALLBACK] = None) -> str:
+def _download_linux(
+        dir: Optional[Union[str, bytes, os.PathLike]],
+        diamond_version: str,
+        bin_name: Optional[str],
+        callback: Optional[CallbackT] = None
+    ) -> str:
     if bin_name is None:
         bin_name = _LINUX_BIN
 
@@ -171,28 +180,18 @@ def _download_linux(dir: Optional[Union[str, bytes, os.PathLike]], diamond_versi
     return os.path.join(dir, bin_name)
 
 
-def _download_archive(dir: Optional[Union[str, bytes, os.PathLike]], diamond_version: str, system: str, ext: str, callback: Optional[_CALLBACK] = None) -> str:
+def _download_archive(
+        dir: Optional[Union[str, bytes, os.PathLike]],
+        diamond_version: str,
+        system: str,
+        ext: str,
+        callback: Optional[CallbackT] = None
+    ) -> str:
     url = _DIAMOND_URL_TEMPLATE.format(version=diamond_version, system=system, ext=ext)
     download_path = os.path.join(dir, "diamond.zip")
 
     try:
-        with request.urlopen(url) as response, open(download_path, "wb") as file:
-            response: http.client.HTTPResponse
-            total_size = int(response.info().get("content-length", 0))
-            block_size = 16 * 1024
-            count = 0
-            
-            while True:
-                chunk = response.read(block_size)
-                if not chunk:
-                    break
-
-                count += 1
-                file.write(chunk)
-
-                if callback is not None:
-                    callback(count, block_size, total_size)
-
+        download(url, download_path, callback)
     except HTTPError as e:
         raise errors.DiamondDownloadError(e, diamond_version, system) from e
 

--- a/src/reconstructor/diamond.py
+++ b/src/reconstructor/diamond.py
@@ -76,13 +76,15 @@ class Diamond:
 
 def get_diamond_path(name: Optional[str] = None) -> Optional[str]:
     """
-    Get the path to a DIAMOND executable or raise an error if one is not found.
+    Get the path to a DIAMOND executable or return None if one is not found.
 
     Checks the following locations (in the order shown) and returns the first
     one that is found:
 
     1. reconstructor/bin/ (a bin folder inside the reconstructor package directory)
     2. The user's PATH by calling `shutil.which(name)`
+
+    If DIAMOND is not found, then `None` is returned.
     """
     if name is None:
         name = "diamond.exe" if platform.system() == "Windows" else "diamond"

--- a/src/reconstructor/diamond.py
+++ b/src/reconstructor/diamond.py
@@ -1,12 +1,10 @@
-from typing import Optional, Callable, Any, Union, Sequence
+from typing import Optional, Union, Sequence
 import tarfile
 import zipfile
 from tempfile import TemporaryDirectory
 import os
 import platform
-from urllib import request
 from urllib.error import HTTPError
-import http.client
 import shutil
 from importlib import resources
 import subprocess
@@ -33,14 +31,16 @@ class Diamond:
             if bin_path is None:
                 raise errors.DiamondNotFoundError()
         self.path: str = str(bin_path)
-    
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({repr(self.path)})"
-    
+
     def __str__(self) -> str:
         return f"DIAMOND v{self.get_version()} ({self.path})"
-    
-    def __call__(self, options: Sequence[str], *args, **kwargs) -> subprocess.CompletedProcess:
+
+    def __call__(
+        self, options: Sequence[str], *args, **kwargs
+    ) -> subprocess.CompletedProcess:
         options = [self.path] + options
         result: subprocess.CompletedProcess = subprocess.run(options, *args, **kwargs)
         try:
@@ -51,26 +51,28 @@ class Diamond:
             return result
 
     def blastp(
-            self,
-            db: Union[str, bytes, os.PathLike],
-            query: Union[str, bytes, os.PathLike],
-            out: Optional[Union[str, bytes, os.PathLike]] = None,
-            *options: str,
-            **sp_kwargs
-        ):
+        self,
+        db: Union[str, bytes, os.PathLike],
+        query: Union[str, bytes, os.PathLike],
+        out: Optional[Union[str, bytes, os.PathLike]] = None,
+        *options: str,
+        **sp_kwargs,
+    ):
         args = ["blastp", "--db", db, "--query", query]
         if out is not None:
             args.extend(["--out", out])
         args.extend([str(x) for x in options])
         return self.__call__(args, **sp_kwargs)
-    
+
     def get_version(self):
         args = ["version"]
-        result: subprocess.CompletedProcess[str] = self.__call__(args, capture_output=True, text=True)
+        result: subprocess.CompletedProcess[str] = self.__call__(
+            args, capture_output=True, text=True
+        )
         pattern = re.compile(r"diamond version (\d+\.\d+\.\d+)")
         version = pattern.sub(r"\1", result.stdout.strip())
         return version
-    
+
 
 def get_diamond_path(name: Optional[str] = None) -> Optional[str]:
     """
@@ -84,7 +86,7 @@ def get_diamond_path(name: Optional[str] = None) -> Optional[str]:
     """
     if name is None:
         name = "diamond.exe" if platform.system() == "Windows" else "diamond"
-    
+
     # Check the bin folder inside reconstructor
     path = _BIN_DIR.joinpath(name)
     if os.path.exists(path):
@@ -95,25 +97,25 @@ def get_diamond_path(name: Optional[str] = None) -> Optional[str]:
 
 
 def download_diamond(
-        dir: Optional[Union[str, bytes, os.PathLike]] = _BIN_DIR,
-        diamond_version: str = DEFAULT_DIAMOND_VERSION,
-        bin_name: Optional[str] = None,
-        callback: Optional[CallbackT] = DownloadProgress("Downloading DIAMOND...")
-    ) -> str:
+    dir: Optional[Union[str, bytes, os.PathLike]] = _BIN_DIR,
+    diamond_version: str = DEFAULT_DIAMOND_VERSION,
+    bin_name: Optional[str] = None,
+    callback: Optional[CallbackT] = DownloadProgress("Downloading DIAMOND..."),
+) -> str:
     """
     Download the appropriate DIAMOND binary for the operating system from
     [GitHub](https://github.com/bbuchfink/diamond/releases).
     """
     if dir is _BIN_DIR and not os.path.exists(_BIN_DIR):
         os.mkdir(_BIN_DIR)
-    
+
     system = platform.system()
     if system == "Windows":
         return _download_windows(dir, diamond_version, bin_name, callback)
-    
+
     if dir is None:
         dir = ""
-    
+
     if system == "Darwin":
         return _download_macos(dir, diamond_version, bin_name, callback)
     if system == "Linux":
@@ -130,16 +132,18 @@ def cleanup_bin():
 
 
 def _download_windows(
-        dir: Optional[Union[str, bytes, os.PathLike]],
-        diamond_version: str,
-        bin_name: Optional[str],
-        callback: Optional[CallbackT] = None
-    ) -> str:
+    dir: Optional[Union[str, bytes, os.PathLike]],
+    diamond_version: str,
+    bin_name: Optional[str],
+    callback: Optional[CallbackT] = None,
+) -> str:
     if bin_name is None:
         bin_name = _WINDOWS_BIN
 
     with TemporaryDirectory() as tempdir:
-        download_path = _download_archive(tempdir, diamond_version, "windows", ".zip", callback)
+        download_path = _download_archive(
+            tempdir, diamond_version, "windows", ".zip", callback
+        )
         with zipfile.ZipFile(download_path, "r") as zfile:
             zfile.extract(bin_name, dir)
 
@@ -147,46 +151,50 @@ def _download_windows(
 
 
 def _download_macos(
-        dir: Optional[Union[str, bytes, os.PathLike]],
-        diamond_version: str,
-        bin_name: Optional[str],
-        callback: Optional[CallbackT] = None
-    ) -> str:
+    dir: Optional[Union[str, bytes, os.PathLike]],
+    diamond_version: str,
+    bin_name: Optional[str],
+    callback: Optional[CallbackT] = None,
+) -> str:
     if bin_name is None:
         bin_name = _MACOS_BIN
 
     with TemporaryDirectory() as tempdir:
-        download_path = _download_archive(tempdir, diamond_version, "macos", ".tar.gz", callback)
+        download_path = _download_archive(
+            tempdir, diamond_version, "macos", ".tar.gz", callback
+        )
         with tarfile.open(download_path, "r:gz") as tar:
             tar.extract(bin_name, dir)
-    
+
     return os.path.join(dir, bin_name)
 
 
 def _download_linux(
-        dir: Optional[Union[str, bytes, os.PathLike]],
-        diamond_version: str,
-        bin_name: Optional[str],
-        callback: Optional[CallbackT] = None
-    ) -> str:
+    dir: Optional[Union[str, bytes, os.PathLike]],
+    diamond_version: str,
+    bin_name: Optional[str],
+    callback: Optional[CallbackT] = None,
+) -> str:
     if bin_name is None:
         bin_name = _LINUX_BIN
 
     with TemporaryDirectory() as tempdir:
-        download_path = _download_archive(tempdir, diamond_version, "linux64", ".tar.gz", callback)
+        download_path = _download_archive(
+            tempdir, diamond_version, "linux64", ".tar.gz", callback
+        )
         with tarfile.open(download_path, "r:gz") as tar:
             tar.extract(bin_name, dir)
-    
+
     return os.path.join(dir, bin_name)
 
 
 def _download_archive(
-        dir: Optional[Union[str, bytes, os.PathLike]],
-        diamond_version: str,
-        system: str,
-        ext: str,
-        callback: Optional[CallbackT] = None
-    ) -> str:
+    dir: Optional[Union[str, bytes, os.PathLike]],
+    diamond_version: str,
+    system: str,
+    ext: str,
+    callback: Optional[CallbackT] = None,
+) -> str:
     url = _DIAMOND_URL_TEMPLATE.format(version=diamond_version, system=system, ext=ext)
     download_path = os.path.join(dir, "diamond.zip")
 

--- a/src/reconstructor/diamond.py
+++ b/src/reconstructor/diamond.py
@@ -98,7 +98,7 @@ def download_diamond(
         dir: Optional[Union[str, bytes, os.PathLike]] = _BIN_DIR,
         diamond_version: str = DEFAULT_DIAMOND_VERSION,
         bin_name: Optional[str] = None,
-        callback: Optional[CallbackT] = DownloadProgress()
+        callback: Optional[CallbackT] = DownloadProgress("Downloading DIAMOND...")
     ) -> str:
     """
     Download the appropriate DIAMOND binary for the operating system from

--- a/src/reconstructor/errors.py
+++ b/src/reconstructor/errors.py
@@ -6,6 +6,7 @@ class ReconstructorError(Exception):
     """
     Base class for Reconstructor errors.
     """
+
     pass
 
 
@@ -13,6 +14,7 @@ class DiamondError(ReconstructorError):
     """
     Base class for errors originating from DIAMOND.
     """
+
     pass
 
 
@@ -35,7 +37,7 @@ class DiamondDownloadError(DiamondError, HTTPError):
     The error raised if an HTTPError is encountered while trying to download
     DIAMOND.
     """
-    
+
     def __init__(self, error: HTTPError, version, system):
         super().__init__(error.url, error.code, error.msg, error.hdrs, error.fp)
         self.version = version
@@ -58,5 +60,5 @@ class DiamondProcessError(DiamondError, subprocess.CalledProcessError):
             returncode=error.returncode,
             cmd=error.cmd,
             output=error.output,
-            stderr=error.stderr
+            stderr=error.stderr,
         )

--- a/src/reconstructor/medium.py
+++ b/src/reconstructor/medium.py
@@ -1,0 +1,145 @@
+from typing import Sequence
+
+
+_media_dict: dict[str, list[str]] = {}
+
+
+def get_medium(name: str):
+    global _media_dict
+    medium = _media_dict.get(name)
+    if medium is None:
+        raise KeyError(f"{repr(name)} is not a registered medium.")
+    return medium
+
+
+def register(medium: Sequence[str], name: str):
+    global _media_dict
+    _media_dict[name] = list(medium)
+
+
+RICH = [
+    "cpd00001_e",
+    "cpd00035_e",
+    "cpd00041_e",
+    "cpd00023_e",
+    "cpd00119_e",
+    "cpd00107_e",
+    "cpd00060_e",
+    "cpd00161_e",
+    "cpd00069_e",
+    "cpd00084_e",
+    "cpd00033_e",
+    "cpd00322_e",
+    "cpd00066_e",
+    "cpd00054_e",
+    "cpd00065_e",
+    "cpd00156_e",
+    "cpd00220_e",
+    "cpd00644_e",
+    "cpd00393_e",
+    "cpd00133_e",
+    "cpd00263_e",
+    "cpd00104_e",
+    "cpd00149_e",
+    "cpd00971_e",
+    "cpd00099_e",
+    "cpd00205_e",
+    "cpd00009_e",
+    "cpd00063_e",
+    "cpd00254_e",
+    "cpd10515_e",
+    "cpd00030_e",
+    "cpd00242_e",
+    "cpd00226_e",
+    "cpd01242_e",
+    "cpd00307_e",
+    "cpd00092_e",
+    "cpd00117_e",
+    "cpd00067_e",
+    "cpd00567_e",
+    "cpd00132_e",
+    "cpd00210_e",
+    "cpd00320_e",
+    "cpd03279_e",
+    "cpd00246_e",
+    "cpd00311_e",
+    "cpd00367_e",
+    "cpd00277_e",
+    "cpd00182_e",
+    "cpd00654_e",
+    "cpd00412_e",
+    "cpd00438_e",
+    "cpd00274_e",
+    "cpd00186_e",
+    "cpd00637_e",
+    "cpd00105_e",
+    "cpd00305_e",
+    "cpd00309_e",
+    "cpd00098_e",
+    "cpd00207_e",
+    "cpd00082_e",
+    "cpd00129_e"
+]
+
+COMPLETE = [
+    "cpd00035_e",
+    "cpd00051_e",
+    "cpd00132_e",
+    "cpd00041_e",
+    "cpd00084_e",
+    "cpd00053_e",
+    "cpd00023_e",
+    "cpd00033_e",
+    "cpd00119_e",
+    "cpd00322_e",
+    "cpd00107_e",
+    "cpd00039_e",
+    "cpd00060_e",
+    "cpd00066_e",
+    "cpd00129_e",
+    "cpd00054_e",
+    "cpd00161_e",
+    "cpd00065_e",
+    "cpd00069_e",
+    "cpd00156_e",
+    "cpd00027_e",
+    "cpd00149_e",
+    "cpd00030_e",
+    "cpd00254_e",
+    "cpd00971_e",
+    "cpd00063_e",
+    "cpd10515_e",
+    "cpd00205_e",
+    "cpd00099_e"
+]
+
+MINIMAL = [
+    "cpd00001_e",
+    "cpd00065_e",
+    "cpd00060_e",
+    "cpd00322_e",
+    "cpd00129_e",
+    "cpd00156_e",
+    "cpd00107_e",
+    "cpd00084_e", 
+    "cpd00149_e",
+    "cpd00099_e",
+    "cpd10515_e",
+    "cpd00030_e",
+    "cpd00254_e",
+    "cpd00063_e",
+    "cpd00205_e",
+    "cpd00009_e",
+    "cpd00971_e",
+    "cpd00242_e",
+    "cpd00104_e",
+    "cpd00644_e",
+    "cpd00263_e",
+    "cpd00082_e"
+]
+
+
+# Register the media
+register(RICH, "rich")
+register(COMPLETE, "complete")
+register(MINIMAL, "minimal")

--- a/src/reconstructor/medium.py
+++ b/src/reconstructor/medium.py
@@ -78,7 +78,7 @@ RICH = [
     "cpd00098_e",
     "cpd00207_e",
     "cpd00082_e",
-    "cpd00129_e"
+    "cpd00129_e",
 ]
 
 COMPLETE = [
@@ -110,7 +110,7 @@ COMPLETE = [
     "cpd00063_e",
     "cpd10515_e",
     "cpd00205_e",
-    "cpd00099_e"
+    "cpd00099_e",
 ]
 
 MINIMAL = [
@@ -121,7 +121,7 @@ MINIMAL = [
     "cpd00129_e",
     "cpd00156_e",
     "cpd00107_e",
-    "cpd00084_e", 
+    "cpd00084_e",
     "cpd00149_e",
     "cpd00099_e",
     "cpd10515_e",
@@ -135,7 +135,7 @@ MINIMAL = [
     "cpd00104_e",
     "cpd00644_e",
     "cpd00263_e",
-    "cpd00082_e"
+    "cpd00082_e",
 ]
 
 

--- a/src/reconstructor/resources/__init__.py
+++ b/src/reconstructor/resources/__init__.py
@@ -4,8 +4,9 @@ from pathlib import Path
 import gzip
 import json
 
-import wget
 import cobra
+
+from reconstructor.utils import download, DownloadProgress
 
 
 RESOURCE_DIR = resources.files(__package__)
@@ -51,12 +52,12 @@ def get_diamond_db_path() -> Path:
     return Path(RESOURCE_DIR.joinpath("screened_kegg_prokaryotes_pep_db.dmnd"))
 
 
-def download_diamond_db():
+def download_diamond_db() -> Path:
     """
     Downloads the DIAMOND database file from the Reconstructor releases page.
     """
     url = "https://github.com/emmamglass/reconstructor/releases/download/v0.0.1/screened_kegg_prokaryotes_pep_db.dmnd"
-    wget.download(url, out=str(get_diamond_db_path()))
+    return download(url, path=get_diamond_db_path(), callback=DownloadProgress())
 
 
 def remove_diamond_db():

--- a/src/reconstructor/resources/__init__.py
+++ b/src/reconstructor/resources/__init__.py
@@ -57,7 +57,8 @@ def download_diamond_db() -> Path:
     Downloads the DIAMOND database file from the Reconstructor releases page.
     """
     url = "https://github.com/emmamglass/reconstructor/releases/download/v0.0.1/screened_kegg_prokaryotes_pep_db.dmnd"
-    return download(url, path=get_diamond_db_path(), callback=DownloadProgress())
+    progress = DownloadProgress("Downloading the DIAMOND database for blasting...")
+    return download(url, path=get_diamond_db_path(), callback=progress)
 
 
 def remove_diamond_db():

--- a/src/reconstructor/utils.py
+++ b/src/reconstructor/utils.py
@@ -1,4 +1,13 @@
+from typing import Callable, Union, Optional, Any
+import os
 import re
+from urllib import request
+import http.client
+from tempfile import TemporaryDirectory
+import time
+
+
+CallbackT = Callable[[int, int, int], Any]
 
 
 def is_valid_sbml_id(id_: str) -> bool:
@@ -8,6 +17,7 @@ def is_valid_sbml_id(id_: str) -> bool:
     SBML IDs should start either with an underscore (`_`) or a letter and should
     only contain underscores, letters, and numbers.
     """
+
     sbml_pattern = r"^[_a-zA-Z]\w*$"
     return bool(re.match(sbml_pattern, id_))
 
@@ -30,7 +40,60 @@ def sanitize_sbml_id(id_: str):
     >>> sanitize_sbml_id("3-atp")
     '_3_atp'
     """
+
     if len(id_) > 0 and id_[0].isdigit():
         id_ = "_" + id_
     invalid_chars = r"\W+"
     return re.sub(invalid_chars, "_", id_)
+
+
+def download(url: str, path: Union[str, bytes, os.PathLike], callback: Optional[CallbackT] = None):
+    """
+    Download the contents of a url and save to the specified path.
+    """
+
+    with TemporaryDirectory() as tmpdir:
+        tmp_path = os.path.join(tmpdir, "download.tmp")
+        
+        # Download contents to a temporary path
+        with request.urlopen(url) as response, open(tmp_path, "wb") as file:
+            response: http.client.HTTPResponse
+            total_size = int(response.info().get("content-length", 0))
+            block_size = 16 * 1024
+            count = 0
+            
+            while True:
+                chunk = response.read(block_size)
+                if not chunk:
+                    break
+
+                count += 1
+                file.write(chunk)
+
+                if callback is not None:
+                    callback(count, block_size, total_size)
+
+        # Rename the temporary downloaded file to the provided path
+        os.replace(tmp_path, path)
+    
+    return path
+
+
+class DownloadProgress:
+    """
+    A callback object to display the progress of a download.
+    """
+
+    def __init__(self, msg: str = "Downloading...", freq: float = 0.05):
+        self.msg: str = msg
+        self.freq: float = freq
+        self._prev: Optional[float] = None
+
+    def __call__(self, count: int, block: int, total: int) -> None:
+        now = time.monotonic()
+        finished = count*block >= total
+        if self._prev is None or finished or (now - self._prev) >= self.freq:
+            self._prev = now
+            progress = f"\r{self.msg} {count*block/total:.1%}"
+            end = "\n" if finished else ""
+            print(progress, end=end, flush=True)

--- a/src/reconstructor/utils.py
+++ b/src/reconstructor/utils.py
@@ -1,0 +1,36 @@
+import re
+
+
+def is_valid_sbml_id(id_: str) -> bool:
+    """
+    Checks if an ID is a valid SBML ID.
+
+    SBML IDs should start either with an underscore (`_`) or a letter and should
+    only contain underscores, letters, and numbers.
+    """
+    sbml_pattern = r"^[_a-zA-Z]\w*$"
+    return bool(re.match(sbml_pattern, id_))
+
+
+def sanitize_sbml_id(id_: str):
+    """
+    Formats an ID to be a valid SBML ID.
+
+    Replaces any invalid characters (e.g., spaces, dashes, etc.) with `_` and
+    adds `_` at the beginning if the string starts with a number. Note that if a
+    string contains a sequence of multiple invalid characters in a row, the
+    sequence of characters will be replaced by a single underscore.
+
+    Examples
+    --------
+    >>> sanitize_sbml_id("a_valid_id")
+    'a_valid_id'
+    >>> sanitize_sbml_id("an invalid--id #3")
+    'an_invalid_id_3'
+    >>> sanitize_sbml_id("3-atp")
+    '_3_atp'
+    """
+    if len(id_) > 0 and id_[0].isdigit():
+        id_ = "_" + id_
+    invalid_chars = r"\W+"
+    return re.sub(invalid_chars, "_", id_)

--- a/src/reconstructor/utils.py
+++ b/src/reconstructor/utils.py
@@ -3,7 +3,7 @@ import os
 import re
 from urllib import request
 import http.client
-from tempfile import TemporaryDirectory
+from tempfile import NamedTemporaryFile
 import time
 
 
@@ -54,31 +54,83 @@ def download(
     Download the contents of a url and save to the specified path.
     """
 
-    with TemporaryDirectory() as tmpdir:
-        tmp_path = os.path.join(tmpdir, "download.tmp")
+    # Download contents (first to temporary path and then gets renamed when exiting `with` block)
+    with request.urlopen(url) as response, DownloadFileObj(path) as file:
+        response: http.client.HTTPResponse
+        total_size = int(response.info().get("content-length", 0))
+        block_size = 64 * 1024
+        count = 0
 
-        # Download contents to a temporary path
-        with request.urlopen(url) as response, open(tmp_path, "wb") as file:
-            response: http.client.HTTPResponse
-            total_size = int(response.info().get("content-length", 0))
-            block_size = 64 * 1024
-            count = 0
+        while True:
+            chunk = response.read(block_size)
+            if not chunk:
+                break
 
-            while True:
-                chunk = response.read(block_size)
-                if not chunk:
-                    break
+            count += 1
+            file.write(chunk)
 
-                count += 1
-                file.write(chunk)
-
-                if callback is not None:
-                    callback(count, block_size, total_size)
-
-        # Rename the temporary downloaded file to the provided path
-        os.replace(tmp_path, path)
+            if callback is not None:
+                callback(count, block_size, total_size)
 
     return path
+
+
+class DownloadFileObj:
+    """
+    A file object to handle writing data to a temporary file and then moving the
+    file to a specified path once all data has been written.
+
+    For example, the intended use is for avoiding files that are partially
+    downloaded by first writing the downloaded data to a temporary location and
+    then moving the temporary file to the permanent location once all the data
+    has been downloaded.
+    """
+
+    def __init__(self, path: Union[str, bytes, os.PathLike]):
+        self.path = str(path)
+        self._file = None
+        self._tmppath = None
+
+    def __enter__(self):
+        dirname, basename = os.path.split(self.path)
+        self._file = NamedTemporaryFile(
+            "xb",
+            suffix=".tmp",
+            prefix=basename + "-",
+            dir=dirname,
+            delete=False,
+        )
+        self._tmppath = self._file.name
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.close()
+        if exc_type is None:  # Successful download
+            os.replace(self._tmppath, self.path)
+        self.cleanup()
+        return False
+
+    def write(self, data: bytes):
+        """
+        Write data to the file.
+        """
+        self._file.write(data)
+
+    def close(self):
+        """
+        Close the temporary file, flushing all data in the buffer.
+        """
+        if self._file is not None and not self._file.closed:
+            self._file.flush()
+            os.fsync(self._file.fileno())
+            self._file.close()
+
+    def cleanup(self):
+        """
+        Delete the temporary file if it still exists.
+        """
+        if self._tmppath is not None and os.path.exists(self._tmppath):
+            os.remove(self._tmppath)
 
 
 class DownloadProgress:
@@ -96,6 +148,6 @@ class DownloadProgress:
         finished = count * block >= total
         if self._prev is None or finished or (now - self._prev) >= self.freq:
             self._prev = now
-            progress = f"\r{self.msg} {count*block/total:.1%}"
+            progress = f"\r{self.msg} {min(count*block/total, 1):.1%}"
             end = "\n" if finished else ""
             print(progress, end=end, flush=True)

--- a/src/reconstructor/utils.py
+++ b/src/reconstructor/utils.py
@@ -59,7 +59,7 @@ def download(url: str, path: Union[str, bytes, os.PathLike], callback: Optional[
         with request.urlopen(url) as response, open(tmp_path, "wb") as file:
             response: http.client.HTTPResponse
             total_size = int(response.info().get("content-length", 0))
-            block_size = 16 * 1024
+            block_size = 64 * 1024
             count = 0
             
             while True:

--- a/src/reconstructor/utils.py
+++ b/src/reconstructor/utils.py
@@ -47,21 +47,23 @@ def sanitize_sbml_id(id_: str):
     return re.sub(invalid_chars, "_", id_)
 
 
-def download(url: str, path: Union[str, bytes, os.PathLike], callback: Optional[CallbackT] = None):
+def download(
+    url: str, path: Union[str, bytes, os.PathLike], callback: Optional[CallbackT] = None
+):
     """
     Download the contents of a url and save to the specified path.
     """
 
     with TemporaryDirectory() as tmpdir:
         tmp_path = os.path.join(tmpdir, "download.tmp")
-        
+
         # Download contents to a temporary path
         with request.urlopen(url) as response, open(tmp_path, "wb") as file:
             response: http.client.HTTPResponse
             total_size = int(response.info().get("content-length", 0))
             block_size = 64 * 1024
             count = 0
-            
+
             while True:
                 chunk = response.read(block_size)
                 if not chunk:
@@ -75,7 +77,7 @@ def download(url: str, path: Union[str, bytes, os.PathLike], callback: Optional[
 
         # Rename the temporary downloaded file to the provided path
         os.replace(tmp_path, path)
-    
+
     return path
 
 
@@ -91,7 +93,7 @@ class DownloadProgress:
 
     def __call__(self, count: int, block: int, total: int) -> None:
         now = time.monotonic()
-        finished = count*block >= total
+        finished = count * block >= total
         if self._prev is None or finished or (now - self._prev) >= self.freq:
             self._prev = now
             progress = f"\r{self.msg} {count*block/total:.1%}"

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -7,6 +7,8 @@ belong in any of the other test files.
 import pytest
 import cobra
 
+from reconstructor import medium
+
 
 def test_write_sbml(universal_model: cobra.Model, tmp_path):
     """
@@ -25,3 +27,14 @@ def test_write_sbml(universal_model: cobra.Model, tmp_path):
     # Test writing the model
     model_path = tmp_path / "model.sbml"
     cobra.io.write_sbml_model(new_model, str(model_path))
+
+
+def test_medium():
+    test_medium = ["a", "b", "c", "d", "e"]
+    medium.register(test_medium, "test")
+    assert test_medium == medium.get_medium("test")
+
+
+def test_medium_error():
+    with pytest.raises(KeyError):
+        medium.get_medium("missing")


### PR DESCRIPTION
The main update in this PR is refactoring the package so that the model reconstruction logic is housed within the `build` module instead of `__main__`.  This way, calling `reconstructor.reconstruct` doesn't have to call `Reconstructor` as a script using `os.system` under the hood. Instead, it simply executes the model reconstruction logic. Meanwhile, the `__main__` script now calls the `reconstruct` function in the `build` module where all of the reconstruction logic is housed.

Other updates:

- Removed the wget dependency by adding a download function in the `utils` module that uses `urllib`.
- Added `ruff` and `black` as dev dependencies for linting/style checks.